### PR TITLE
feat: define Terraform outputs for Ansible

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,12 @@
+# Terraform state file
+*.tfstate
+*.tfstate.backup
+
+# Terraform plan file
+*.tfplan
+
+# Terraform provider plugins
+.terraform/
+
+# Terraform lock file
+.terraform.lock.hcl

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "ansible_inventory" {
+  sensitive = true
+  value = {
+    k3s_masters = {
+      hosts = {
+        for vm in proxmox_vm_qemu.k3s_master :
+        vm.name => {
+          ansible_host = cidrhost(var.network_cidr, index(proxmox_vm_qemu.k3s_master.*.name, vm.name) + 4)
+        }
+      }
+    }
+    k3s_workers = {
+      hosts = {
+        for vm in proxmox_vm_qemu.k3s_worker :
+        vm.name => {
+          ansible_host = cidrhost(var.network_cidr, index(proxmox_vm_qemu.k3s_worker.*.name, vm.name) + 4 + var.k3s_master_count)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Creates a structured output in outputs.tf that contains all the necessary information for Ansible to connect to the newly provisioned VMs.

An output named ansible_inventory is created. The output value is a map that follows the structure outlined in the design document, with nested groups for k3s_masters and k3s_workers.

Each host entry in the output includes its ansible_host (the provisioned IP address).

The output is marked as sensitive = true as a best practice.