### PR TITLE
feat: Integrate HashiCorp Vault for secret management

### DIFF
--- a/ansible/playbooks/test.yml
+++ b/ansible/playbooks/test.yml
@@ -1,0 +1,6 @@
+---
+- name: Setup Core Applications
+  hosts: localhost
+  connection: local
+  roles:
+    - core_apps

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -2,3 +2,5 @@
 collections:
   - name: kubernetes.core
     version: "2.3.0"
+  - name: community.hashi_vault
+    version: "2.2.0"

--- a/ansible/roles/core_apps/templates/coder-ingressroute.yml.j2
+++ b/ansible/roles/core_apps/templates/coder-ingressroute.yml.j2
@@ -18,4 +18,4 @@ spec:
         - name: authelia-forward-auth
           namespace: security
   tls:
-    secretName: coder-tls
+    secretName: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/coder/tls') }}"

--- a/ansible/roles/core_apps/templates/gitea-ingressroute.yml.j2
+++ b/ansible/roles/core_apps/templates/gitea-ingressroute.yml.j2
@@ -18,4 +18,4 @@ spec:
         - name: authelia-forward-auth
           namespace: security
   tls:
-    secretName: gitea-tls
+    secretName: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/gitea/tls') }}"

--- a/ansible/roles/core_apps/templates/gitea-values.yml.j2
+++ b/ansible/roles/core_apps/templates/gitea-values.yml.j2
@@ -1,6 +1,6 @@
 gitea:
   admin:
-    existingSecret: gitea-admin-secret
+    existingSecret: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/gitea/admin') }}"
   persistence:
     enabled: true
     storageClassName: "longhorn"
@@ -35,7 +35,7 @@ gitea:
   postgresql:
     auth:
       username: gitea
-      password: "{{ gitea_db_password }}"
+      password: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/gitea/db_password') }}"
       database: gitea
     primary:
       persistence:

--- a/ansible/roles/core_apps/templates/grafana-ingressroute.yml.j2
+++ b/ansible/roles/core_apps/templates/grafana-ingressroute.yml.j2
@@ -18,4 +18,4 @@ spec:
         - name: authelia-forward-auth
           namespace: security
   tls:
-    secretName: grafana-tls
+    secretName: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/grafana/tls') }}"

--- a/ansible/roles/core_apps/templates/monitoring-values.yml.j2
+++ b/ansible/roles/core_apps/templates/monitoring-values.yml.j2
@@ -6,7 +6,7 @@ grafana:
     size: 2Gi
   ingress:
     enabled: false # We will use an IngressRoute instead
-  adminPassword: "{{ grafana_admin_password }}"
+  adminPassword: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/grafana/admin_password') }}"
 
 prometheus:
   enabled: true

--- a/ansible/roles/core_apps/templates/pihole-ingressroute.yml.j2
+++ b/ansible/roles/core_apps/templates/pihole-ingressroute.yml.j2
@@ -18,4 +18,4 @@ spec:
         - name: authelia-forward-auth
           namespace: security
   tls:
-    secretName: pihole-tls
+    secretName: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/pihole/tls') }}"

--- a/ansible/roles/core_infra/defaults/main.yml
+++ b/ansible/roles/core_infra/defaults/main.yml
@@ -45,7 +45,7 @@ authelia_values:
     oidc:
       clients:
         - id: "my-app"
-          secret: "my-secret"
+          secret: "{{ lookup('community.hashi_vault.vault_read', 'secret/homelab/authelia/oidc_client_secret') }}"
           redirect_uris:
             - "https://my-app.example.com/oauth2/callback"
 


### PR DESCRIPTION
This commit updates all Ansible tasks that use secrets to fetch them directly from HashiCorp Vault using the `community.hashi_vault.vault_read` lookup plugin.

Changes include:
- Updated gitea.yml, monitoring.yml, and other related files to use the Vault lookup.
- Added the `community.hashi_vault` collection to `requirements.yml`.