### PR TITLE
feat: Update Pi-hole to use Vault secret

### DIFF
--- a/apps/pihole.yml
+++ b/apps/pihole.yml
@@ -14,8 +14,8 @@ spec:
     helm:
       values: |
         adminPassword:
-          name: pihole-admin-password
-          key: password
+          secretName: pihole-admin-password
+          secretKey: password
         persistence:
           enabled: true
           storageClassName: "local-path"


### PR DESCRIPTION
Updates the Pi-hole ArgoCD Application manifest to use the Kubernetes secret created by the Vault Secrets Operator for the admin password.