### PR TITLE
feat: Centralize user management with OpenLDAP

### DIFF
--- a/ansible/roles/core_infra/tasks/grafana.yml
+++ b/ansible/roles/core_infra/tasks/grafana.yml
@@ -1,0 +1,10 @@
+- name: Create Grafana LDAP secret
+  kubernetes.core.k8s:
+    state: present
+    template:
+      - path: grafana-ldap.toml.j2
+        dest: /tmp/grafana-ldap.toml
+    dest: "{{ grafana_ldap_secret_dest }}"
+    namespace: monitoring
+  vars:
+    grafana_ldap_secret_dest: /tmp/grafana-ldap-secret.yml

--- a/ansible/roles/core_infra/tasks/main.yml
+++ b/ansible/roles/core_infra/tasks/main.yml
@@ -7,3 +7,6 @@
 
 - name: Deploy Vault
   ansible.builtin.include_tasks: vault.yml
+
+- name: Configure Grafana
+  ansible.builtin.include_tasks: grafana.yml

--- a/ansible/roles/core_infra/templates/grafana-ldap.toml.j2
+++ b/ansible/roles/core_infra/templates/grafana-ldap.toml.j2
@@ -1,0 +1,16 @@
+[[servers]]
+host = "openldap.openldap.svc.cluster.local"
+port = 389
+use_ssl = false
+start_tls = false
+ssl_skip_verify = true
+bind_dn = "cn=admin,dc=homelab,dc=com"
+bind_password = '{{ .lookup "vault" "secret/data/grafana" "ldap_password" }}'
+search_filter = "(uid=%s)"
+search_base_dns = ["ou=users,dc=homelab,dc=com"]
+
+[servers.group_mappings]
+group_dn = "cn=homelab-admins,ou=groups,dc=homelab,dc=com"
+org_role = "Admin"
+grafana_admin = true
+org_id = 1

--- a/apps/gitea.yml
+++ b/apps/gitea.yml
@@ -47,11 +47,11 @@ spec:
               existingSecret: gitea-ldap-secret
               host: "openldap.openldap.svc.cluster.local"
               port: 389
-              userSearchBase: "ou=users,dc=homelab,dc=dev"
+              userSearchBase: "ou=users,dc=homelab,dc=com"
               userFilter: "(&(objectClass=inetOrgPerson)(uid=%s))"
-              adminFilter: "(memberOf=cn=homelab-admins,ou=groups,dc=homelab,dc=dev)"
+              adminFilter: "(memberOf=cn=homelab-admins,ou=groups,dc=homelab,dc=com)"
               emailAttribute: "mail"
-              bindDn: "cn=admin,dc=homelab,dc=dev"
+              bindDn: "cn=admin,dc=homelab,dc=com"
               usernameAttribute: "uid"
   destination:
     server: 'https://kubernetes.default.svc'

--- a/apps/monitoring.yml
+++ b/apps/monitoring.yml
@@ -15,6 +15,14 @@ spec:
           adminPassword:
             existingSecret: grafana-admin-creds
             key: password
+          grafana.ini:
+            auth.ldap:
+              enabled: true
+              config_file: /etc/grafana/ldap.toml
+              allow_sign_up: true
+          ldap:
+            enabled: true
+            existingSecret: grafana-ldap-secret
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: monitoring


### PR DESCRIPTION
This commit centralizes user management by configuring Gitea and Grafana to use OpenLDAP for authentication.

Changes:
- Corrected the Gitea LDAP configuration in `apps/gitea.yml` to use the correct domain.
- Configured Grafana to use LDAP for authentication by adding a new `grafana.ini` configuration and an LDAP configuration file.
- Created a new ansible task to manage the Grafana LDAP configuration.

Note to you:
Please run the ansible playbook `ansible/playbooks/setup.yml` to apply the changes to your environment.