### PR TITLE
feat: Enhance CI/CD with Gitea and Argo CD

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -48,3 +48,29 @@ jobs:
         with:
           name: tfplan
           path: terraform/tfplan
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: homelab-importer
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/homelab-importer:latest
+  trigger-argocd-sync:
+    runs-on: ubuntu-latest
+    needs: build-and-push-image
+    steps:
+      - name: Trigger Argo CD Sync
+        uses: appleboy/argocd-sync-action@master
+        with:
+          server_url: ${{ secrets.ARGOCD_SERVER_URL }}
+          auth_token: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+          app_name: 'homelab-importer'

--- a/apps/homelab-importer.yml
+++ b/apps/homelab-importer.yml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: homelab-importer
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/user/homelab-importer.git'
+    path: charts/puter
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - values.yaml
+      parameters:
+        - name: "image.repository"
+          value: "your-dockerhub-username/homelab-importer"
+        - name: "image.tag"
+          value: "latest"
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/homelab-importer/Dockerfile
+++ b/homelab-importer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "src/main.py"]


### PR DESCRIPTION
This commit enhances the CI/CD pipeline by adding the following features:

- A Dockerfile for the `homelab-importer` application.
- A new job to the Gitea workflow to build and push the container image to a container registry.
- An Argo CD application manifest to deploy the `homelab-importer` application.
- A new job to the Gitea workflow to trigger an Argo CD sync after the image is pushed to the registry.