### PR TITLE
Refactor and harden security

### DIFF
--- a/apps/openldap.yml
+++ b/apps/openldap.yml
@@ -12,8 +12,10 @@ spec:
     helm:
       values: |
         auth:
-          rootPassword: <path:secrets/data/openldap#root-password>
-          adminPassword: <path:secrets/data/openldap#admin-password>
+          rootPasswordSecret: openldap-creds
+          rootPasswordKey: root-password
+          adminPasswordSecret: openldap-creds
+          adminPasswordKey: admin-password
         persistence:
           enabled: true
           storageClassName: "longhorn"

--- a/homelab-importer/src/terraform.py
+++ b/homelab-importer/src/terraform.py
@@ -60,6 +60,8 @@ def generate_import_script(
             # Construct the Proxmox resource ID
             node = resource["attributes"].get("target_node")
             vmid = resource["attributes"].get("vmid")
+            if not node or not vmid:
+                continue
             if resource_type == "proxmox_vm_qemu":
                 resource_id = f"{node}/qemu/{vmid}"
                 f.write(

--- a/homelab-infra/main.tf
+++ b/homelab-infra/main.tf
@@ -15,5 +15,5 @@ provider "proxmox" {
   pm_api_url = var.pm_api_url
   pm_api_user = var.pm_api_user
   pm_api_pass = data.vault_generic_secret.proxmox_credentials.data["password"]
-  pm_tls_insecure = true
+  pm_tls_insecure = false
 }

--- a/minio/defaults/main.yml
+++ b/minio/defaults/main.yml
@@ -2,6 +2,6 @@
 # defaults file for minio
 
 minio_version: "RELEASE.2023-01-25T00-19-53Z"
-minio_access_key: "minio"
-minio_secret_key: "minio123"
+minio_access_key: "{{ vault_minio_access_key }}"
+minio_secret_key: "{{ vault_minio_secret_key }}"
 minio_data_dir: "/data"


### PR DESCRIPTION
This commit addresses several security vulnerabilities and improves code quality.

- I removed hardcoded credentials from `minio/defaults/main.yml`.
- I enforced TLS validation in `homelab-infra/main.tf`.
- I updated `apps/openldap.yml` to use Kubernetes secrets for passwords.
- I added a check for missing attributes in `homelab-importer/src/terraform.py`.