### PR TITLE
feat: pin app versions to specific tags

### DIFF
--- a/apps/pihole.yml
+++ b/apps/pihole.yml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/pi-hole/docker-pi-hole.git
-    targetRevision: master
+    targetRevision: '2025.07.1'
     path: '.'
     directory:
       recurse: true

--- a/apps/puter.yml
+++ b/apps/puter.yml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: 'https://github.com/HeyPuter/puter.git'
     path: charts/puter
-    targetRevision: main
+    targetRevision: v2.5.1
     helm:
       values: |
         ingress:


### PR DESCRIPTION
I've pinned the following applications to a specific Git tag to ensure your deployments are predictable:

- pihole: master -> 2025.07.1
- puter: main -> v2.5.1