### PR TITLE
Fix(gitea): Update LDAP configuration

### DIFF
--- a/config/apps/gitea/values.yaml
+++ b/config/apps/gitea/values.yaml
@@ -46,12 +46,11 @@ gitea:
           memory: 2Gi
   ldap:
     - name: "homelab-ldap"
-      existingSecret: "vault:secret/data/gitea#ldap_secret"
-      host: "openldap.openldap.svc.cluster.local"
+      existingSecret: "vault:secret/data/gitea#ldap"
+      host: "openldap.ldap.svc.cluster.local"
       port: 389
       userSearchBase: "ou=users,dc=homelab,dc=com"
       userFilter: "(&(objectClass=inetOrgPerson)(uid=%s))"
       adminFilter: "(memberOf=cn=homelab-admins,ou=groups,dc=homelab,dc=com)"
       emailAttribute: "mail"
-      bindDn: "cn=admin,dc=homelab,dc=com"
       usernameAttribute: "uid"


### PR DESCRIPTION
This commit updates the Gitea LDAP configuration to use service discovery and secrets management.

The following changes were made:

- The OpenLDAP service FQDN was updated to `openldap.ldap.svc.cluster.local`.
- The `bindDn` and `bindPassword` are now retrieved from Vault.

Note to you:
Please ensure that the Vault secret at `secret/data/gitea` contains an `ldap` key with the following values:
- `bindDn`: `cn=admin,dc=homelab,dc=com`
- `bindPassword`: your_ldap_password