### PR TITLE
feat: Enhance observability with EFK and Prometheus/Grafana

### DIFF
--- a/ansible/roles/efk_stack/templates/fluentd.conf.j2
+++ b/ansible/roles/efk_stack/templates/fluentd.conf.j2
@@ -1,0 +1,44 @@
+<source>
+  @type tail
+  path /var/log/containers/traefik-*.log
+  pos_file /var/log/fluentd-traefik.pos
+  tag traefik.*
+  <parse>
+    @type json
+    time_key time
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+  </parse>
+</source>
+
+<filter traefik.**>
+  @type parser
+  key_name log
+  <parse>
+    @type json
+  </parse>
+</filter>
+
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+<match *.**>
+  @type copy
+  <store>
+    @type elasticsearch
+    host {{ efk_elasticsearch_name }}.{{ efk_namespace }}.svc.cluster.local
+    port 9200
+    logstash_format true
+    logstash_prefix fluentd
+    logstash_dateformat %Y%m%d
+    include_tag_key true
+    type_name access_log
+    tag_key @log_name
+    flush_interval 1s
+  </store>
+  <store>
+    @type stdout
+  </store>
+</match>

--- a/ansible/roles/efk_stack/templates/fluentd.yml.j2
+++ b/ansible/roles/efk_stack/templates/fluentd.yml.j2
@@ -4,30 +4,7 @@ metadata:
   name: fluentd-config
   namespace: {{ efk_namespace }}
 data:
-  fluent.conf: |
-    <source>
-      @type forward
-      port 24224
-      bind 0.0.0.0
-    </source>
-    <match *.**>
-      @type copy
-      <store>
-        @type elasticsearch
-        host {{ efk_elasticsearch_name }}.{{ efk_namespace }}.svc.cluster.local
-        port 9200
-        logstash_format true
-        logstash_prefix fluentd
-        logstash_dateformat %Y%m%d
-        include_tag_key true
-        type_name access_log
-        tag_key @log_name
-        flush_interval 1s
-      </store>
-      <store>
-        @type stdout
-      </store>
-    </match>
+  fluent.conf: {{ lookup('template', 'fluentd.conf.j2') | to_nice_json }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/ansible/roles/homelab/tasks/grafana.yml
+++ b/ansible/roles/homelab/tasks/grafana.yml
@@ -8,3 +8,17 @@
     namespace: monitoring
   vars:
     grafana_ldap_secret_dest: /tmp/grafana-ldap-secret.yml
+
+- name: Create Traefik dashboard
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: traefik-dashboard
+        namespace: monitoring
+        labels:
+          grafana_dashboard: "1"
+      data:
+        traefik.json: "{{ lookup('template', 'traefik-dashboard.json.j2') }}"

--- a/ansible/roles/homelab/tasks/main.yml
+++ b/ansible/roles/homelab/tasks/main.yml
@@ -25,3 +25,8 @@
   kubernetes.core.k8s:
     state: present
     src: "{{ role_path }}/../../../apps/sabnzbd.yml"
+
+- name: Deploy MinIO ServiceMonitor
+  k8s:
+    template: minio-servicemonitor.yml.j2
+    state: present

--- a/ansible/roles/homelab/templates/minio-servicemonitor.yml.j2
+++ b/ansible/roles/homelab/templates/minio-servicemonitor.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: minio-exporter
+  namespace: {{ minio_namespace }}
+  labels:
+    app: minio-exporter
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: minio-exporter
+  endpoints:
+  - port: http
+    interval: 15s

--- a/ansible/roles/homelab/templates/traefik-dashboard.json.j2
+++ b/ansible/roles/homelab/templates/traefik-dashboard.json.j2
@@ -1,0 +1,391 @@
+{
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.2.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "rows": [
+    {
+      "collapse": false,
+      "height": 287,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": null,
+          "decimals": 0,
+          "format": "s",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 3,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "targets": [
+            {
+              "expr": "time() - process_start_time_seconds{job=\"traefik\"}",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 60
+            }
+          ],
+          "thresholds": "",
+          "title": "Uptime",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "fill": 1,
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 5,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "traefik_requests_total{service=\"http\"}",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{method}} {{code}}",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total Status Code Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "Count",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "fill": 1,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 5,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "traefik_request_duration_seconds_sum{service=\"http\"}",
+              "intervalFactor": 2,
+              "legendFormat": "Average response time (ms)",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Average response time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 382,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "decimals": 0,
+          "fill": 1,
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "traefik_requests_total{service!~\"http\"}",
+              "intervalFactor": 2,
+              "legendFormat": "{{service}} {{method}} {{code}}",
+              "refId": "A",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Detailed Status Code Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Traefik Stats",
+  "version": 0
+}

--- a/ansible/roles/minio/handlers/main.yml
+++ b/ansible/roles/minio/handlers/main.yml
@@ -5,3 +5,7 @@
   systemd:
     name: minio
     state: restarted
+- name: restart minio-exporter
+  systemd:
+    name: minio-exporter
+    state: restarted

--- a/ansible/roles/minio/tasks/main.yml
+++ b/ansible/roles/minio/tasks/main.yml
@@ -41,3 +41,35 @@
     state: started
     enabled: yes
     daemon_reload: yes
+
+- name: Download and install minio exporter binary
+  get_url:
+    url: "https://github.com/prometheus/minio-exporter/releases/download/v0.0.12/minio-exporter-0.0.12.linux-amd64.tar.gz"
+    dest: /tmp/minio-exporter.tar.gz
+
+- name: Unarchive minio exporter
+  unarchive:
+    src: /tmp/minio-exporter.tar.gz
+    dest: /tmp
+    remote_src: yes
+
+- name: Move minio exporter binary
+  copy:
+    src: /tmp/minio-exporter-0.0.12.linux-amd64/minio-exporter
+    dest: /usr/local/bin/minio-exporter
+    mode: '0755'
+    remote_src: yes
+  notify: restart minio-exporter
+
+- name: Create systemd service file for minio exporter
+  template:
+    src: minio-exporter.service.j2
+    dest: /etc/systemd/system/minio-exporter.service
+  notify: restart minio-exporter
+
+- name: Start and enable minio-exporter service
+  systemd:
+    name: minio-exporter
+    state: started
+    enabled: yes
+    daemon_reload: yes

--- a/ansible/roles/minio/templates/exporter.yml.j2
+++ b/ansible/roles/minio/templates/exporter.yml.j2
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-exporter
+  namespace: {{ minio_namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-exporter
+  template:
+    metadata:
+      labels:
+        app: minio-exporter
+    spec:
+      containers:
+      - name: minio-exporter
+        image: prom/minio-exporter:latest
+        args:
+        - --minio.server={{ minio_url }}
+        - --minio.access-key={{ minio_access_key }}
+        - --minio.secret-key={{ minio_secret_key }}
+        ports:
+        - containerPort: 9100
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-exporter
+  namespace: {{ minio_namespace }}
+  labels:
+    app: minio-exporter
+spec:
+  ports:
+  - name: http
+    port: 9100
+    protocol: TCP
+  selector:
+    app: minio-exporter

--- a/ansible/roles/minio/templates/minio-exporter.service.j2
+++ b/ansible/roles/minio/templates/minio-exporter.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=MinIO Exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=minio
+Group=minio
+ExecStart=/usr/local/bin/minio-exporter \
+  --minio.server={{ minio_url }} \
+  --minio.access-key={{ minio_access_key }} \
+  --minio.secret-key={{ minio_secret_key }}
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/config/apps/traefik/values.yaml
+++ b/config/apps/traefik/values.yaml
@@ -18,6 +18,8 @@ logs:
     level: INFO
   access:
     enabled: true
+    format: json
+    filePath: "/data/access.log"
 ports:
   web:
     port: 80
@@ -59,3 +61,6 @@ volumes:
     mountPath: /config
     configMap:
       name: main-config
+  - name: access-logs
+    mountPath: /data
+    emptyDir: {}


### PR DESCRIPTION
This commit enhances the observability of the homelab by:

- Configuring Fluentd to parse Traefik's JSON logs.
- Adding a Prometheus exporter for MinIO and configuring Prometheus to scrape it.
- Creating a Grafana dashboard for Traefik.
- Configuring Traefik to output logs in a structured format.