### PR TITLE
feat: Add qBittorrent application

### DIFF
--- a/apps/qbittorrent.yml
+++ b/apps/qbittorrent.yml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: qbittorrent
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/Jules-Recruiter/homelab-SRE-challenge' # This will be replaced by the actual repo URL
+    path: charts/vpn-app
+    targetRevision: HEAD
+    helm:
+      values: |
+        application:
+          image:
+            repository: "linuxserver/qbittorrent"
+            tag: "latest"
+          name: "qbittorrent"
+          port: 8080
+
+        gluetun:
+          vpn:
+            type: "openvpn"
+            provider: "private internet access"
+            region: "ca montreal"
+            credentials:
+              user: "<path:secret/data/qbittorrent#pia_username>"
+              password: "<path:secret/data/qbittorrent#pia_password>"
+
+        service:
+          type: ClusterIP
+          port: 8080
+
+        ingressRoute:
+          enabled: true
+          entryPoints:
+            - websecure
+          routes:
+            - match: Host(`qbittorrent.{{ domain_root }}`)
+              kind: Rule
+              services:
+                - name: qbittorrent
+                  port: 8080
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: qbittorrent
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
This commit adds the qBittorrent application to the homelab.

It uses the generic vpn-app Helm chart to deploy qBittorrent with a VPN connection.

A new file `apps/qbittorrent.yml` is created to define the ArgoCD application.

A new file `config/apps/qbittorrent/values.yaml` is created to allow for user-specific configuration.