### PR TITLE
Fix(vpn-app): Remove command override from helm chart

### DIFF
--- a/charts/vpn-app/templates/deployment.yaml
+++ b/charts/vpn-app/templates/deployment.yaml
@@ -47,11 +47,3 @@ spec:
           imagePullPolicy: {{ .Values.application.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.application.port }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              # Wait for gluetun to be ready
-              while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8888/v1/openvpn/status)" != "200" ]]; do sleep 1; done
-              # Replace this with the actual command to start your application
-              /bin/sh


### PR DESCRIPTION
The vpn-app helm chart was overriding the container's default command with a placeholder script that would exit immediately. This prevented any application using the chart from starting correctly.

This change removes the command override, allowing the container's entrypoint to run as intended. This fixes the deployment of sabnzbd, radarr, sonarr, and any other application using this chart.