### PR TITLE
Add the rreading-glasses application

### DIFF
--- a/ansible/roles/rreading-glasses/tasks/main.yml
+++ b/ansible/roles/rreading-glasses/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Create rreading-glasses namespace
+  kubernetes.core.k8s:
+    name: rreading-glasses
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Create rreading-glasses postgres secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: rreading-glasses-secret
+        namespace: rreading-glasses
+      type: Opaque
+      stringData:
+        POSTGRES_PASSWORD: "a-very-secret-password" # This should be changed or managed by a secret management system

--- a/apps/postgres.yml
+++ b/apps/postgres.yml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://charts.bitnami.com/bitnami'
+    chart: postgresql
+    targetRevision: 12.1.6 # Using a specific version for stability
+    helm:
+      values: |
+        auth:
+          database: rreading-glasses
+          username: rreading-glasses
+          password: "a-very-secret-password" # This should be changed or managed by a secret management system
+        primary:
+          persistence:
+            enabled: true
+            size: 1Gi
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: postgres
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/rreading-glasses.yml
+++ b/apps/rreading-glasses.yml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rreading-glasses
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/jmgrimes/homelab-apps.git'
+    path: charts/rreading-glasses
+    targetRevision: HEAD
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: rreading-glasses
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/rreading-glasses/Chart.yaml
+++ b/charts/rreading-glasses/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rreading-glasses
+description: A Helm chart for deploying rreading-glasses
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/rreading-glasses/templates/deployment.yaml
+++ b/charts/rreading-glasses/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.application.name }}
+  labels:
+    app: {{ .Values.application.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.application.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.application.name }}
+    spec:
+      containers:
+        - name: {{ .Values.application.name }}
+          image: "{{ .Values.application.image.repository }}:{{ .Values.application.image.tag }}"
+          imagePullPolicy: {{ .Values.application.image.pullPolicy }}
+          args:
+{{ .Values.application.args | toYaml | indent 12 }}
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secret.name }}
+                  key: {{ .Values.secret.key }}
+          ports:
+            - containerPort: {{ .Values.application.port }}

--- a/charts/rreading-glasses/templates/service.yaml
+++ b/charts/rreading-glasses/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.application.name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.application.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Values.application.name }}

--- a/charts/rreading-glasses/values.yaml
+++ b/charts/rreading-glasses/values.yaml
@@ -1,0 +1,35 @@
+# Default values for rreading-glasses.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+application:
+  image:
+    repository: blampe/rreading-glasses
+    tag: latest
+    pullPolicy: IfNotPresent
+  name: rreading-glasses
+  port: 8788
+  args:
+    - "serve"
+    - "--postgres-host=postgres-postgresql.postgres.svc.cluster.local"
+    - "--postgres-user=rreading-glasses"
+    - "--postgres-password=$(POSTGRES_PASSWORD)"
+    - "--postgres-database=rreading-glasses"
+
+# This is where we will get the password from.
+# It will be a secret in the same namespace.
+secret:
+  name: rreading-glasses-secret
+  key: POSTGRES_PASSWORD
+
+service:
+  type: ClusterIP
+  port: 8788
+
+ingress:
+  enabled: true
+  hosts:
+    - host: rreading-glasses.homelab.dev
+      paths:
+        - path: /
+          pathType: ImplementationSpecific

--- a/scripts/applications.yml
+++ b/scripts/applications.yml
@@ -1,1 +1,4 @@
 # This playbook will deploy user-facing applications.
+- hosts: localhost
+  roles:
+    - rreading-glasses


### PR DESCRIPTION
This change adds the `rreading-glasses` application to the homelab setup.

- Creates a new Ansible role to manage the `rreading-glasses` namespace and a secret for the Postgres password.
- Creates a new Helm chart for the `rreading-glasses` application.
- Adds an ArgoCD application to deploy a Postgres database using the Bitnami Helm chart.
- Adds an ArgoCD application to deploy the `rreading-glasses` application using the new Helm chart.
- Updates the Ansible playbooks to include the new role.