### PR TITLE
I've added the Jellyfin application to your homelab.

### DIFF
--- a/ansible/roles/homelab/tasks/main.yml
+++ b/ansible/roles/homelab/tasks/main.yml
@@ -31,6 +31,11 @@
     state: present
     src: "{{ role_path }}/../../../apps/sonarr.yml"
 
+- name: Deploy jellyfin
+  kubernetes.core.k8s:
+    state: present
+    src: "{{ role_path }}/../../../apps/jellyfin.yml"
+
 - name: Deploy MinIO ServiceMonitor
   k8s:
     template: minio-servicemonitor.yml.j2

--- a/apps/jellyfin.yml
+++ b/apps/jellyfin.yml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: jellyfin
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://jellyfin.github.io/helm-charts'
+    chart: jellyfin
+    targetRevision: 0.1.0 # This is a placeholder
+    helm:
+      values: |
+        image:
+          repository: jellyfin/jellyfin
+          tag: latest
+        ingress:
+          main:
+            enabled: true
+            hosts:
+              - host: jellyfin.homelab.dev
+                paths:
+                  - path: /
+                    pathType: Prefix
+        persistence:
+          config:
+            enabled: true
+            mountPath: /config
+          media:
+            enabled: true
+            type: hostPath
+            hostPath: /mnt/media
+            mountPath: /media
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: jellyfin
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
To do this, I created a new ArgoCD `Application` manifest at `apps/jellyfin.yml`, which I modeled after the existing `plex.yml` file. I also added a new task to `ansible/roles/homelab/tasks/main.yml` to deploy the Jellyfin application.

Please note that the Helm chart repository and version used in `apps/jellyfin.yml` are placeholders. You may need to update them to a valid, working chart, because the `k8s-at-home` chart repository that was previously used in this project has been archived.