### PR TITLE
feat: Add bolt.new application

### DIFF
--- a/apps/bolt.yml
+++ b/apps/bolt.yml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bolt
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/toxicoder/homelabeazy.git'
+    path: charts/bolt
+    targetRevision: HEAD
+    helm:
+      values: |
+        ingress:
+          hosts: bolt.homelab.dev
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: bolt
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/bolt/Chart.yaml
+++ b/charts/bolt/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: bolt
+description: A Helm chart for bolt.new
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/bolt/Dockerfile
+++ b/charts/bolt/Dockerfile
@@ -1,0 +1,28 @@
+# Build stage
+FROM node:20-alpine AS builder
+
+# Install git and pnpm
+RUN apk add --no-cache git && npm install -g pnpm@9.4.0
+
+# Clone the repository
+WORKDIR /app
+RUN git clone https://github.com/stackblitz/bolt.new.git .
+
+# Install dependencies and build the application
+RUN pnpm install --frozen-lockfile && pnpm run build
+
+# Production stage
+FROM node:20-alpine
+
+# Install serve
+RUN npm install -g serve
+
+# Set up a work directory
+WORKDIR /app
+
+# Copy the built application from the builder stage
+COPY --from=builder /app/build/client ./
+
+# Expose the port and start the server
+EXPOSE 3000
+CMD ["serve", "-s", ".", "-l", "3000"]

--- a/charts/bolt/templates/_helpers.tpl
+++ b/charts/bolt/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bolt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bolt.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bolt.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bolt.labels" -}}
+helm.sh/chart: {{ include "bolt.chart" . }}
+{{ include "bolt.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bolt.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bolt.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bolt.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bolt.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/bolt/templates/deployment.yaml
+++ b/charts/bolt/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bolt.fullname" . }}
+  labels:
+    {{- include "bolt.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "bolt.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "bolt.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bolt.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/bolt/templates/service.yaml
+++ b/charts/bolt/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bolt.fullname" . }}
+  labels:
+    {{- include "bolt.labels" . | nindent 4 }}
+    traefik.enable: "true"
+    traefik.http.routers.bolt.rule: "Host(`{{ .Values.ingress.hosts }}`)"
+    traefik.http.routers.bolt.entrypoints: "websecure"
+    traefik.http.routers.bolt.tls.certresolver: "letsencrypt"
+    traefik.http.services.bolt.loadbalancer.server.port: "{{ .Values.service.port }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "bolt.selectorLabels" . | nindent 4 }}

--- a/charts/bolt/values.yaml
+++ b/charts/bolt/values.yaml
@@ -1,0 +1,78 @@
+# Default values for bolt.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: bolt
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts: bolt.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the
+  # following lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This commit adds the `bolt.new` application to the homelab.

Since there is no official Docker image or Helm chart for `bolt.new`, this commit includes a new Helm chart and a `Dockerfile` to build the application.

The new application is defined in `apps/bolt.yml` and will be deployed by ArgoCD.

A new Helm chart for `bolt` is added in `charts/bolt`. This chart is based on the `puter` chart.

A `Dockerfile` is included in `charts/bolt/Dockerfile` to build the `bolt.new` application from source. You will need to build this image and make it available to the Kubernetes cluster. The image name in `charts/bolt/values.yaml` is set to `bolt:latest` as a placeholder.