### PR TITLE
feat: Add workadventure application

### DIFF
--- a/ansible/roles/homelab/tasks/main.yml
+++ b/ansible/roles/homelab/tasks/main.yml
@@ -41,6 +41,11 @@
     state: present
     src: "{{ role_path }}/../../../apps/jellyseerr.yml"
 
+- name: Deploy workadventure
+  kubernetes.core.k8s:
+    state: present
+    src: "{{ role_path }}/../../../apps/workadventure.yml"
+
 - name: Deploy MinIO ServiceMonitor
   k8s:
     template: minio-servicemonitor.yml.j2

--- a/apps/workadventure.yml
+++ b/apps/workadventure.yml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workadventure
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://charts.workadventu.re/'
+    chart: workadventure
+    targetRevision: 1.25.12
+    helm:
+      valueFiles:
+        - "config/apps/workadventure/values.yaml"
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: workadventure
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
This change adds the workadventure application to the list of available applications.

It includes:
- An ArgoCD Application manifest for workadventure in `apps/workadventure.yml`.
- A default values file in `config/apps/workadventure/values.yaml` with placeholders for secrets.
- An Ansible task in `ansible/roles/homelab/tasks/main.yml` to deploy the application.