### PR TITLE
feat: Add AppFlowy application

### DIFF
--- a/apps/appflowy.yml
+++ b/apps/appflowy.yml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: appflowy
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/toxicoder/homelabeazy.git'
+    path: charts/appflowy
+    targetRevision: HEAD
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: appflowy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/appflowy/Chart.yaml
+++ b/charts/appflowy/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: appflowy
+description: A Helm chart for AppFlowy
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/appflowy/templates/_helpers.tpl
+++ b/charts/appflowy/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "appflowy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "appflowy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "appflowy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "appflowy.labels" -}}
+helm.sh/chart: {{ include "appflowy.chart" . }}
+{{ include "appflowy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "appflowy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "appflowy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "appflowy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "appflowy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/appflowy/templates/deployment.yaml
+++ b/charts/appflowy/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "appflowy.fullname" . }}
+  labels:
+    {{- include "appflowy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "appflowy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "appflowy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "appflowy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: appflowy-bin
+          emptyDir: {}
+      initContainers:
+        - name: download-appflowy
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              VERSION={{ .Values.initContainer.appflowy.version }}
+              OS="unknown-linux-gnu"
+              ARCH="x86_64"
+              DISTRO="ubuntu-20.04"
+              TARBALL="AppFlowy_${ARCH}-${OS}_${DISTRO}.tar.gz"
+              DOWNLOAD_URL="https://github.com/AppFlowy-IO/AppFlowy/releases/download/${VERSION}/${TARBALL}"
+              echo "Downloading AppFlowy from ${DOWNLOAD_URL}"
+              wget -O /tmp/appflowy.tar.gz ${DOWNLOAD_URL}
+              echo "Extracting AppFlowy"
+              tar -xzvf /tmp/appflowy.tar.gz -C /appflowy-bin/
+              echo "AppFlowy extracted"
+          volumeMounts:
+            - name: appflowy-bin
+              mountPath: /appflowy-bin
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/appflowy-bin/AppFlowy"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: appflowy-bin
+              mountPath: /appflowy-bin
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/appflowy/templates/service.yaml
+++ b/charts/appflowy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "appflowy.fullname" . }}
+  labels:
+    {{- include "appflowy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "appflowy.selectorLabels" . | nindent 4 }}

--- a/charts/appflowy/values.yaml
+++ b/charts/appflowy/values.yaml
@@ -1,0 +1,91 @@
+# Default values for appflowy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ubuntu
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+initContainer:
+  image:
+    repository: busybox
+    tag: latest
+  appflowy:
+    version: "0.9.5" # This is the latest version I saw on the releases page
+    # The URL will be constructed in the deployment template
+    # Example: https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.9.5/AppFlowy_x86_64-unknown-linux-gnu_ubuntu-20.04.tar.gz
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the
+  # following lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This commit introduces the AppFlowy application to the homelab.

Since there is no official Helm chart or Docker image for AppFlowy, a new Helm chart has been created from scratch in `charts/appflowy`.

The deployment uses an initContainer to download the pre-compiled binary from the official GitHub releases, and then runs it in a standard Ubuntu container. This avoids the need to build and maintain a custom Docker image.

An ArgoCD Application manifest has been added at `apps/appflowy.yml` to deploy the chart.