### PR TITLE
feat: Add Terraform configuration for Bazzite LXC

### DIFF
--- a/infrastructure/proxmox/bazzite_lxc/README.md
+++ b/infrastructure/proxmox/bazzite_lxc/README.md
@@ -1,0 +1,37 @@
+# Bazzite LXC for Proxmox
+
+This directory contains Terraform configuration to create a Bazzite LXC container on a Proxmox server.
+
+## Prerequisites
+
+Before you can use this configuration, you must have a Bazzite LXC template available in your Proxmox environment. You will need to provide the name of this template in the `ostemplate` variable.
+
+As official Bazzite LXC images may not be available, you might need to create your own.
+
+## Usage
+
+1.  Initialize Terraform in this directory:
+    ```bash
+    terraform init
+    ```
+2.  Create a `terraform.tfvars` file to specify the required variables, for example:
+    ```terraform
+    target_node = "pve"
+    vmid        = 200
+    ostemplate  = "local:vztmpl/bazzite-template.tar.gz"
+    ```
+3.  Apply the Terraform configuration:
+    ```bash
+    terraform apply
+    ```
+
+## Variables
+
+| Name         | Description                                                                    | Type   | Default | Required |
+|--------------|--------------------------------------------------------------------------------|--------|---------|----------|
+| `hostname`   | The hostname of the Bazzite LXC.                                               | `string` | `bazzite` | No       |
+| `target_node`| The Proxmox node to create the LXC on.                                         | `string` | n/a     | Yes      |
+| `vmid`       | The VM ID of the LXC.                                                          | `number` | n/a     | Yes      |
+| `memory`     | The amount of memory for the LXC in MB.                                        | `number` | `4096`  | No       |
+| `cores`      | The number of CPU cores for the LXC.                                           | `number` | `2`     | No       |
+| `ostemplate` | The Proxmox template to use for the LXC. This must be a Bazzite template.      | `string` | n/a     | Yes      |

--- a/infrastructure/proxmox/bazzite_lxc/main.tf
+++ b/infrastructure/proxmox/bazzite_lxc/main.tf
@@ -1,0 +1,20 @@
+resource "proxmox_lxc" "bazzite_lxc" {
+  hostname      = var.hostname
+  target_node   = var.target_node
+  vmid          = var.vmid
+  memory        = var.memory
+  cores         = var.cores
+  ostemplate    = var.ostemplate
+  unprivileged  = true
+
+  rootfs {
+    storage = "local-lvm"
+    size    = "8G"
+  }
+
+  network {
+    name   = "eth0"
+    bridge = "vmbr0"
+    ip     = "dhcp"
+  }
+}

--- a/infrastructure/proxmox/bazzite_lxc/variables.tf
+++ b/infrastructure/proxmox/bazzite_lxc/variables.tf
@@ -1,0 +1,32 @@
+variable "hostname" {
+  description = "The hostname of the Bazzite LXC."
+  type        = string
+  default     = "bazzite"
+}
+
+variable "target_node" {
+  description = "The Proxmox node to create the LXC on."
+  type        = string
+}
+
+variable "vmid" {
+  description = "The VM ID of the LXC."
+  type        = number
+}
+
+variable "memory" {
+  description = "The amount of memory for the LXC in MB."
+  type        = number
+  default     = 4096
+}
+
+variable "cores" {
+  description = "The number of CPU cores for the LXC."
+  type        = number
+  default     = 2
+}
+
+variable "ostemplate" {
+  description = "The Proxmox template to use for the LXC. This must be a Bazzite template."
+  type        = string
+}


### PR DESCRIPTION
This commit introduces a new Terraform module for creating a Bazzite LXC container in Proxmox.

The module includes:
- A `main.tf` file to define the `proxmox_lxc` resource.
- A `variables.tf` file to allow for customization of the LXC.
- A `README.md` file that explains how to use the module and its prerequisites.

The configuration is based on the existing LXC configurations in the repository and is designed to be self-contained.