### PR TITLE
I will refactor the k3s_cluster Ansible role to improve security and …

### DIFF
--- a/ansible/roles/k3s_cluster/tasks/generate_token.yml
+++ b/ansible/roles/k3s_cluster/tasks/generate_token.yml
@@ -1,0 +1,13 @@
+---
+- name: Generate k3s join token
+  community.hashi_vault.vault_kv2_write:
+    url: "{{ vault_addr }}"
+    token: "{{ vault_token }}"
+    mount_point: "secret"
+    path: "k3s"
+    data:
+      join_token: "{{ lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}"
+  register: k3s_join_token_result
+  until: k3s_join_token_result is success
+  retries: 5
+  delay: 2

--- a/ansible/roles/k3s_cluster/tasks/install_master.yml
+++ b/ansible/roles/k3s_cluster/tasks/install_master.yml
@@ -6,10 +6,8 @@
     mode: '0755'
   delegate_to: "{{ item }}"
 
-- name: Install k3s agent
+- name: Install k3s server
   command: "/tmp/k3s-install.sh"
   environment:
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
-    K3S_URL: "https://{{ groups['k3s_masters'][0] }}:6443"
-    K3S_TOKEN: "{{ lookup('community.hashi_vault.vault_read', 'secret/k3s')['data']['join_token'] }}"
   delegate_to: "{{ item }}"

--- a/ansible/roles/k3s_cluster/tasks/main.yml
+++ b/ansible/roles/k3s_cluster/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Deploy k3s cluster
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Generate and store k3s join token
+      include_tasks: generate_token.yml
+
+    - name: Install k3s master(s)
+      include_tasks: install_master.yml
+      loop: "{{ groups['k3s_masters'] }}"
+
+    - name: Install k3s worker(s)
+      include_tasks: install_worker.yml
+      loop: "{{ groups['k3s_workers'] }}"


### PR DESCRIPTION
…modularity.

Key changes:
- Use HashiCorp Vault to manage the K3s join token, removing the need to store it in temporary files.
- Reorganize tasks into separate files for token generation, master installation, and worker installation.
- Create a main.yml to orchestrate the deployment process.