### PR TITLE
Fix: Harden security configurations and manage secrets with Vault

### DIFF
--- a/.gitea/gitleaks.toml
+++ b/.gitea/gitleaks.toml
@@ -3,8 +3,7 @@
 description = "Allowlist for this repository"
 paths = [
     '''gitleaks.toml''',
-    '''minio/README.md''',
-    '''gitleaks-report.json''',
+    '''ansible/roles/minio/README.md''',
 ]
 
 [[rules]]

--- a/ansible/roles/pfsense/tasks/main.yml
+++ b/ansible/roles/pfsense/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Allow traffic from service network to the internet
+- name: Allow HTTP/HTTPS traffic from service network to the internet
   community.general.pfsense_rule:
     config_file: "/cf/conf/config.xml"
     rule:
@@ -9,4 +9,5 @@
         network: "opt1"
       destination:
         any: true
+        port: "http,https"
     state: "present"

--- a/ansible/roles/velero/defaults/main.yml
+++ b/ansible/roles/velero/defaults/main.yml
@@ -5,5 +5,6 @@ velero_version: "1.9.0"
 velero_install_dir: "/opt/velero"
 
 # The following variables should be set in a secure way, e.g. using Ansible Vault
-minio_access_key: ""
-minio_secret_key: ""
+velero_minio_vault_path: "secret/data/minio"
+velero_minio_vault_access_key_name: "access_key"
+velero_minio_vault_secret_key_name: "secret_key"

--- a/ansible/roles/velero/tasks/main.yml
+++ b/ansible/roles/velero/tasks/main.yml
@@ -22,6 +22,11 @@
     remote_src: yes
   notify: restart velero
 
+- name: Get Minio credentials from vault
+  ansible.builtin.set_fact:
+    velero_minio_credentials: "{{ lookup('community.hashi_vault.vault_kv2_get', velero_minio_vault_path, engine_mount_point='secret') }}"
+  no_log: true
+
 - name: Create Velero secret
   kubernetes.core.k8s:
     state: present
@@ -34,8 +39,8 @@
       stringData:
         cloud: |
           [default]
-          aws_access_key_id={{ minio_access_key }}
-          aws_secret_access_key={{ minio_secret_key }}
+          aws_access_key_id={{ velero_minio_credentials[velero_minio_vault_access_key_name] }}
+          aws_secret_access_key={{ velero_minio_credentials[velero_minio_vault_secret_key_name] }}
 
 - name: Install velero
   command: >


### PR DESCRIPTION
This commit addresses several security vulnerabilities in the HomelabEazy project.

The main changes include:
- Refactored the `velero` Ansible role to securely fetch Minio credentials from HashiCorp Vault, removing the need for hardcoded secrets.
- Made the pfSense firewall rule more restrictive, now only allowing HTTP and HTTPS traffic from the service network to the internet.
- Tightened the Gitleaks configuration to reduce the chance of false positives.

During the implementation, it was discovered that several of the secrets mentioned in the code review (OpenLDAP, router WiFi, and SSH passwords) were already being managed securely using Ansible Vault.

Note on testing:
The project has a large number of `ansible-lint` errors (171 failures). These are pre-existing issues and are not related to the changes in this commit. The changes I made follow the best practices (e.g., using FQCN for Ansible modules). A separate effort should be made to address the technical debt and fix the linting errors across the codebase, as outlined in the "Consistency and Best Practices" section of the code review.