### PR TITLE
Refactor: Apply improvements from report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,26 +114,21 @@ jobs:
         with:
           go-version: '1.22'
 
-      - name: Run tests
+      - name: Run Go tests
         working-directory: ./infrastructure/proxmox
         run: go test -v ./test/...
 
-  python-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: |
           pip install -r tools/homelab-importer/requirements.txt
           pip install flake8 pytest coverage
       - name: Run flake8
         run: flake8 tools/homelab-importer/
-      - name: Run tests with coverage
+      - name: Run Python tests with coverage
         run: |
           cd tools/homelab-importer
           coverage run -m unittest discover tests/

--- a/ansible/roles/minio/tasks/main.yml
+++ b/ansible/roles/minio/tasks/main.yml
@@ -34,13 +34,16 @@
     mode: '0755'
   notify: restart minio
 
+- name: Set service credentials
+  set_fact:
+    service_user: "{{ minio_credentials.data[minio_vault_access_key_name] }}"
+    service_password: "{{ minio_credentials.data[minio_vault_secret_key_name] }}"
+  no_log: true
+
 - name: Create systemd service file
   template:
     src: minio.service.j2
     dest: /etc/systemd/system/minio.service
-  vars:
-    minio_root_user: "{{ minio_credentials.data[minio_vault_access_key_name] }}"
-    minio_root_password: "{{ minio_credentials.data[minio_vault_secret_key_name] }}"
   notify: restart minio
 
 - name: Start and enable minio service

--- a/ansible/roles/minio/templates/exporter.yml.j2
+++ b/ansible/roles/minio/templates/exporter.yml.j2
@@ -18,8 +18,8 @@ spec:
         image: prom/minio-exporter:latest
         args:
         - --minio.server={{ minio_url }}
-        - --minio.access-key={{ minio_access_key }}
-        - --minio.secret-key={{ minio_secret_key }}
+        - --minio.access-key={{ service_user }}
+        - --minio.secret-key={{ service_password }}
         ports:
         - containerPort: 9100
 ---

--- a/ansible/roles/minio/templates/minio-exporter.service.j2
+++ b/ansible/roles/minio/templates/minio-exporter.service.j2
@@ -8,8 +8,8 @@ User=minio
 Group=minio
 ExecStart=/usr/local/bin/minio-exporter \
   --minio.server={{ minio_url }} \
-  --minio.access-key={{ minio_access_key }} \
-  --minio.secret-key={{ minio_secret_key }}
+  --minio.access-key={{ service_user }} \
+  --minio.secret-key={{ service_password }}
 Restart=always
 
 [Install]

--- a/ansible/roles/minio/templates/minio.service.j2
+++ b/ansible/roles/minio/templates/minio.service.j2
@@ -7,8 +7,8 @@ After=network-online.target
 [Service]
 User=minio
 Group=minio
-Environment="MINIO_ROOT_USER={{ minio_root_user }}"
-Environment="MINIO_ROOT_PASSWORD={{ minio_root_password }}"
+Environment="MINIO_ROOT_USER={{ service_user }}"
+Environment="MINIO_ROOT_PASSWORD={{ service_password }}"
 ExecStart=/usr/local/bin/minio server {{ minio_data_dir }}
 
 [Install]

--- a/ansible/roles/openldap/defaults/main.yml
+++ b/ansible/roles/openldap/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-openldap_root_password: "{{ vault_openldap_root_password }}"
-openldap_admin_password: "{{ vault_openldap_admin_password }}"
+service_password: "{{ vault_openldap_root_password }}"
+service_admin_password: "{{ vault_openldap_admin_password }}"

--- a/ansible/roles/openldap/templates/openldap-values.yml.j2
+++ b/ansible/roles/openldap/templates/openldap-values.yml.j2
@@ -1,6 +1,6 @@
 auth:
-  rootPassword: {{ openldap_root_password }}
-  adminPassword: {{ openldap_admin_password }}
+  rootPassword: {{ service_password }}
+  adminPassword: {{ service_admin_password }}
 customLdif: |
 {{ lookup('file', '../files/bootstrap.ldif') | indent(2) }}
 persistence:

--- a/ansible/roles/secure-gen/files/secure-gen
+++ b/ansible/roles/secure-gen/files/secure-gen
@@ -23,14 +23,17 @@ def generate_secrets(config):
                 generate_password(secret["alias"])
 
 def get_vault_client():
-    # It's recommended to use environment variables for Vault address and token
     vault_addr = os.environ.get("VAULT_ADDR", "http://127.0.0.1:8200")
-    vault_token = os.environ.get("VAULT_TOKEN")
+    role_id = os.environ.get("VAULT_ROLE_ID")
+    secret_id = os.environ.get("VAULT_SECRET_ID")
 
-    if not vault_token:
-        raise ValueError("VAULT_TOKEN environment variable is not set")
+    if not role_id or not secret_id:
+        raise ValueError("VAULT_ROLE_ID and VAULT_SECRET_ID environment variables must be set")
 
-    return hvac.Client(url=vault_addr, token=vault_token)
+    client = hvac.Client(url=vault_addr)
+    client.auth.approle.login(role_id=role_id, secret_id=secret_id)
+
+    return client
 
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/infrastructure/proxmox/modules/k3s-cluster/main.tf
+++ b/infrastructure/proxmox/modules/k3s-cluster/main.tf
@@ -1,39 +1,32 @@
-resource "proxmox_vm_qemu" "k3s_master" {
-  name        = "k3s-master"
-  target_node = var.target_node
-  clone       = var.clone
-  vmid        = var.master_vm_id
-  memory      = var.master_memory
-  sockets     = var.master_sockets
-  cores       = var.master_cores
-  os_type     = "cloud-init"
-  agent       = var.agent
+module "k3s-master" {
+  source = "../k3s-node"
 
-  network {
-    bridge  = var.network_bridge
-    macaddr = var.mac
-    tag     = var.vlan_tag
-    model   = "virtio"
-  }
+  name           = "k3s-master"
+  target_node    = var.target_node
+  clone          = var.clone
+  vmid           = var.master_vm_id
+  memory         = var.master_memory
+  sockets        = var.master_sockets
+  cores          = var.master_cores
+  agent          = var.agent
+  network_bridge = var.network_bridge
+  mac            = var.mac
+  vlan_tag       = var.vlan_tag
 }
 
-resource "proxmox_vm_qemu" "k3s_worker" {
-  count = var.worker_count
+module "k3s-worker" {
+  source = "../k3s-node"
+  count  = var.worker_count
 
-  name        = "k3s-worker-${count.index}"
-  target_node = var.target_node
-  clone       = var.clone
-  vmid        = var.worker_vm_id_start + count.index
-  memory      = var.worker_memory
-  sockets     = var.worker_sockets
-  cores       = var.worker_cores
-  os_type     = "cloud-init"
-  agent       = var.agent
-
-  network {
-    bridge  = var.network_bridge
-    macaddr = var.mac
-    tag     = var.vlan_tag
-    model   = "virtio"
-  }
+  name           = "k3s-worker-${count.index}"
+  target_node    = var.target_node
+  clone          = var.clone
+  vmid           = var.worker_vm_id_start + count.index
+  memory         = var.worker_memory
+  sockets        = var.worker_sockets
+  cores          = var.worker_cores
+  agent          = var.agent
+  network_bridge = var.network_bridge
+  mac            = var.mac
+  vlan_tag       = var.vlan_tag
 }

--- a/infrastructure/proxmox/modules/k3s-node/main.tf
+++ b/infrastructure/proxmox/modules/k3s-node/main.tf
@@ -1,0 +1,18 @@
+resource "proxmox_vm_qemu" "node" {
+  name        = var.name
+  target_node = var.target_node
+  clone       = var.clone
+  vmid        = var.vmid
+  memory      = var.memory
+  sockets     = var.sockets
+  cores       = var.cores
+  os_type     = "cloud-init"
+  agent       = var.agent
+
+  network {
+    bridge  = var.network_bridge
+    macaddr = var.mac
+    tag     = var.vlan_tag
+    model   = "virtio"
+  }
+}

--- a/infrastructure/proxmox/modules/k3s-node/variables.tf
+++ b/infrastructure/proxmox/modules/k3s-node/variables.tf
@@ -1,0 +1,55 @@
+variable "name" {
+  description = "The name of the VM."
+  type        = string
+}
+
+variable "target_node" {
+  description = "The Proxmox node to create the VM on."
+  type        = string
+}
+
+variable "clone" {
+  description = "The template to clone."
+  type        = string
+}
+
+variable "vmid" {
+  description = "The VM ID."
+  type        = number
+}
+
+variable "memory" {
+  description = "The amount of memory in MB."
+  type        = number
+}
+
+variable "sockets" {
+  description = "The number of CPU sockets."
+  type        = number
+}
+
+variable "cores" {
+  description = "The number of CPU cores."
+  type        = number
+}
+
+variable "agent" {
+  description = "Enable/disable the QEMU agent."
+  type        = number
+  default     = 1
+}
+
+variable "network_bridge" {
+  description = "The network bridge."
+  type        = string
+}
+
+variable "mac" {
+  description = "The MAC address of the network interface."
+  type        = string
+}
+
+variable "vlan_tag" {
+  description = "The VLAN tag."
+  type        = number
+}

--- a/scripts/configure-proxmox.sh
+++ b/scripts/configure-proxmox.sh
@@ -21,7 +21,7 @@ fi
 
 # Enable community repository
 COMMUNITY_REPO_FILE="/etc/apt/sources.list.d/pve-community.list"
-COMMUNITY_REPO_LINE="deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription"
+COMMUNITY_REPO_LINE=${PROXMOX_COMMUNITY_REPO:-"deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription"}
 if [ -f "$COMMUNITY_REPO_FILE" ]; then
     if grep -q "$COMMUNITY_REPO_LINE" "$COMMUNITY_REPO_FILE"; then
         echo "Community repository already enabled."


### PR DESCRIPTION
This commit applies a series of refactorings to the HomelabEazy codebase based on the provided report.

- Standardized Ansible variable names in the `minio` and `openldap` roles to `service_user` and `service_password`.
- Removed hardcoded repository URL in `configure_proxmox.sh` and replaced it with an environment variable.
- Consolidated redundant `test` and `python-test` CI/CD jobs into a single `test` job.
- Improved Terraform modularity by creating a `k3s-node` module to reduce duplication.
- Enhanced security in the `secure-gen` script by replacing Vault token authentication with AppRole authentication.