### PR TITLE
This commit includes the following changes:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,20 @@ on:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Lint YAML files
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .yamllint.yml
+          file_or_dir: ./apps
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
-
-      - name: Terraform fmt
-        run: terraform fmt --check
 
       - name: TFLint
         uses: terraform-linters/setup-tflint@v3
@@ -27,89 +31,31 @@ jobs:
       - name: TFLint recursive
         run: tflint --recursive
 
-      - name: Lint YAML files
-        uses: ibiqlik/action-yamllint@v3
-        with:
-          config_file: .yamllint.yml
-          file_or_dir: ./apps
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.15.2
-
-      - name: Lint Helm charts
-        run: |
-          for chart in ./charts/*; do
-            if [ -d "$chart" ]; then
-              helm lint "$chart"
-            fi
-          done
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-
-      - name: Install Prettier
-        run: npm install -g prettier
-      - name: Run Prettier
-        run: prettier --check .
-
-      - name: Install Biome
-        run: |
-          curl -fsSL https://biomejs.dev/install.sh | bash
-          mv biome /usr/local/bin/
-      - name: Run Biome
-        run: biome check .
-
-      - name: Install Unibeautify CLI
-        run: npm install -g @unibeautify/cli
-      - name: Run Unibeautify
-        run: unibeautify --check
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Install Black
-        run: pip install black
-      - name: Run Black
-        run: black --check .
+      - name: Install ansible-lint
+        run: pip install ansible-lint
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
+      - name: Run Ansible Lint
+        run: ansible-lint
 
-      - name: Run gofmt
-        run: test -z "$(gofmt -l .)"
+      - name: Install flake8
+        run: pip install flake8
 
-      - name: Install clang-format
-        run: sudo apt-get install -y clang-format
-      - name: Run clang-format
-        run: find . -name "*.h" -o -name "*.cpp" -print0 | xargs -0 clang-format --dry-run -Werror
+      - name: Run flake8
+        run: flake8 tools/homelab-importer/
 
-      - name: Set up Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Download google-java-format
-        run: |
-          wget https://github.com/google/google-java-format/releases/download/google-java-format-1.15.0/google-java-format-1.15.0-all-deps.jar -O /tmp/google-java-format.jar
-      - name: Run google-java-format
-        run: find . -name "*.java" -print0 | xargs -0 java -jar /tmp/google-java-format.jar --dry-run --set-exit-if-changed
-
-  test:
+  test-infra:
+    name: Test Infrastructure
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
@@ -118,30 +64,9 @@ jobs:
         working-directory: ./infrastructure/proxmox
         run: go test -v ./test/...
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install Python dependencies
-        run: |
-          pip install -r tools/homelab-importer/requirements.txt
-          pip install flake8 pytest coverage
-      - name: Run flake8
-        run: flake8 tools/homelab-importer/
-      - name: Run Python tests with coverage
-        run: |
-          cd tools/homelab-importer
-          coverage run -m unittest discover tests/
-          coverage report
-
-  test-synology:
+  test-python:
+    name: Test Python
     runs-on: ubuntu-latest
-    services:
-      mock-synology-api:
-        image: python:3-slim
-        volumes:
-          - ${{ github.workspace }}:/github/workspace
-        command: python /github/workspace/ansible/playbooks/mock_synology_api.py
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -151,29 +76,42 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install ansible requests
+          pip install -r tools/homelab-importer/requirements.txt
+          pip install coverage
+      - name: Run Python tests with coverage
+        run: |
+          cd tools/homelab-importer
+          coverage run -m unittest discover tests/
+          coverage report
 
-      - name: Run Synology playbook
-        run: ansible-playbook ansible/playbooks/test_synology_mock.yml --extra-vars "mock_api_url=http://mock-synology-api:8000"
-
-  ansible-lint:
+  terraform-validate:
+    name: Terraform Validate
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4
-      - name: Set up Python 3.
-        uses: actions/setup-python@v5
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Terraform Init
+        run: terraform -chdir=infrastructure/proxmox init -backend=false
+      - name: Terraform Validate
+        run: terraform -chdir=infrastructure/proxmox validate
+
+  tfsec:
+    name: tfsec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+      - name: tfsec
+        uses: aquasecurity/tfsec-action@v1.0.0
         with:
-          python-version: '3.11'
-      - name: Install test dependencies.
-        run: pip install ansible-lint
-      - name: Run Ansible Lint.
-        run: ansible-lint
+          working_directory: infrastructure/proxmox
 
   ansible-molecule:
+    name: Ansible Molecule
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
@@ -193,28 +131,3 @@ jobs:
               cd -
             fi
           done
-
-  terraform-validate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the codebase.
-        uses: actions/checkout@v4
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-      - name: Terraform Init
-        run: terraform -chdir=infrastructure/proxmox init -backend=false
-      - name: Terraform Validate
-        run: terraform -chdir=infrastructure/proxmox validate
-
-  tfsec:
-    name: tfsec
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Clone repo
-        uses: actions/checkout@v4
-
-      - name: tfsec
-        uses: aquasecurity/tfsec-action@v1.0.0
-        with:
-          working_directory: infrastructure/proxmox

--- a/apps/bitwarden.yml
+++ b/apps/bitwarden.yml
@@ -8,29 +8,29 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://guerzon.github.io/vaultwarden
-    targetRevision: 0.32.1
+    repoURL: 'https://bjw-s.github.io/helm-charts'
     chart: vaultwarden
+    targetRevision: 1.10.1
     helm:
       values: |
         image:
           repository: vaultwarden/server
           tag: 1.40.0
-        ingressRoute:
-          enabled: true
-          entryPoints:
-            - websecure
-          routes:
-            - match: Host(`bitwarden.{{ domain_root }}`)
-              kind: Rule
-              services:
-                - name: bitwarden
-                  port: 80
-              middlewares:
-                - name: authelia
-                  namespace: traefik
-          tls:
-            secretName: bitwarden-tls
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "bitwarden.{{ domain_root }}"
+                paths:
+                  - path: /
+                    pathType: Prefix
+            tls:
+              - secretName: bitwarden-tls
+                hosts:
+                  - "bitwarden.{{ domain_root }}"
         resources:
           requests:
             cpu: 100m

--- a/apps/coder.yml
+++ b/apps/coder.yml
@@ -26,7 +26,7 @@ spec:
             enabled: true
             url: "ldap://openldap.ldap.svc.cluster.local:389"
             bindDN: "cn=admin,dc=homelab,dc=com"
-            bindPassword: "<path:secrets/data/openldap#admin-password>"
+            bindPassword: "<vault:secret/data/openldap#admin-password>"
             userSearch:
               baseDN: "ou=users,dc=homelab,dc=com"
               filter: "(uid=%s)"

--- a/apps/grafana.yml
+++ b/apps/grafana.yml
@@ -11,7 +11,7 @@ spec:
     targetRevision: 6.50.0
     helm:
       values: |
-        adminPassword: <path:secrets/data/grafana#admin-password>
+        adminPassword: <vault:secret/data/grafana#admin-password>
         persistence:
           enabled: true
           storageClassName: "longhorn"

--- a/apps/home-assistant.yml
+++ b/apps/home-assistant.yml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://small-hack.github.io/home-assistant-chart/'
+    repoURL: 'https://bjw-s.github.io/helm-charts'
     chart: home-assistant
-    targetRevision: 1.0.0
+    targetRevision: 9.3.0
     helm:
       values: |
         persistence:

--- a/apps/homepage.yml
+++ b/apps/homepage.yml
@@ -6,24 +6,22 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://aidan-wallace.github.io/homepage-kubernetes/'
+    repoURL: 'https://bjw-s.github.io/helm-charts'
     chart: homepage
-    targetRevision: 0.2.1
+    targetRevision: 1.0.2
     helm:
       values: |
-        ingressRoute:
-          enabled: true
-          entryPoints:
-            - websecure
-          routes:
-            - match: Host(`homepage.homelab.dev`)
-              kind: Rule
-              services:
-                - name: homepage
-                  port: 3000
-        metadata:
-          annotations:
-            traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "homepage.homelab.dev"
+                paths:
+                  - path: /
+                    pathType: Prefix
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: homepage

--- a/apps/kasm.yml
+++ b/apps/kasm.yml
@@ -20,7 +20,7 @@ spec:
           host: "openldap.ldap.svc.cluster.local"
           port: 389
           bindDN: "cn=admin,dc=homelab,dc=com"
-          bindPassword: "<path:secrets/data/openldap#admin-password>"
+          bindPassword: "<vault:secret/data/openldap#admin-password>"
           userSearchBase: "ou=users,dc=homelab,dc=com"
           userSearchFilter: "(&(objectClass=inetOrgPerson)(uid=%s))"
           groupSearchBase: "ou=groups,dc=homelab,dc=com"

--- a/apps/lidarr.yml
+++ b/apps/lidarr.yml
@@ -6,41 +6,26 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/Jules-Recruiter/homelab-SRE-challenge' # This will be replaced by the actual repo URL
-    path: charts/vpn-app
-    targetRevision: HEAD
+    repoURL: 'https://bjw-s.github.io/helm-charts'
+    chart: lidarr
+    targetRevision: 15.0.1
     helm:
       values: |
-        application:
-          image:
-            repository: "linuxserver/lidarr"
-            tag: "latest"
-          name: "lidarr"
-          port: 8686
+        image:
+          repository: "linuxserver/lidarr"
+          tag: "latest"
 
-        gluetun:
-          vpn:
-            type: "openvpn"
-            provider: "private internet access"
-            region: "ca montreal"
-            credentials:
-              user: "<path:secret/data/lidarr#pia_username>"
-              password: "<path:secret/data/lidarr#pia_password>"
-
-        service:
-          type: ClusterIP
-          port: 8686
-
-        ingressRoute:
-          enabled: true
-          entryPoints:
-            - websecure
-          routes:
-            - match: Host(`lidarr.{{ domain_root }}`)
-              kind: Rule
-              services:
-                - name: lidarr
-                  port: 8686
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "lidarr.{{ domain_root }}"
+                paths:
+                  - path: /
+                    pathType: Prefix
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: lidarr

--- a/apps/mariadb.yml
+++ b/apps/mariadb.yml
@@ -12,10 +12,10 @@ spec:
     helm:
       values: |
         auth:
-          rootPassword: <path:secrets/data/mariadb#root-password>
+          rootPassword: <vault:secret/data/mariadb#root-password>
           database: "gitea"
           username: "gitea"
-          password: <path:secrets/data/gitea#db_creds>
+          password: <vault:secret/data/gitea#db_creds>
         primary:
           persistence:
             enabled: true

--- a/apps/monitoring.yml
+++ b/apps/monitoring.yml
@@ -12,7 +12,7 @@ spec:
     helm:
       values: |
         grafana:
-          adminPassword: <path:secrets/data/grafana#admin-password>
+          adminPassword: <vault:secret/data/grafana#admin-password>
           grafana.ini:
             auth.ldap:
               enabled: true
@@ -28,7 +28,7 @@ spec:
               start_tls = false
               ssl_skip_verify = true
               bind_dn = "cn=admin,dc=homelab,dc=com"
-              bind_password = "<path:secrets/data/openldap#admin-password>"
+              bind_password = "<vault:secret/data/openldap#admin-password>"
               search_filter = "(uid=%s)"
               search_base_dns = ["ou=users,dc=homelab,dc=com"]
 

--- a/apps/openldap.yml
+++ b/apps/openldap.yml
@@ -12,8 +12,8 @@ spec:
     helm:
       values: |
         auth:
-          rootPassword: <path:secrets/data/openldap#root-password>
-          adminPassword: <path:secrets/data/openldap#admin-password>
+          rootPassword: <vault:secret/data/openldap#root-password>
+          adminPassword: <vault:secret/data/openldap#admin-password>
         persistence:
           enabled: true
           storageClassName: "longhorn"

--- a/apps/pihole.yml
+++ b/apps/pihole.yml
@@ -6,14 +6,12 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/pi-hole/docker-pi-hole.git
-    targetRevision: '2025.07.1'
-    path: '.'
-    directory:
-      recurse: true
+    repoURL: https://mojo2600.github.io/pihole-helm
+    targetRevision: 0.13.2
+    chart: pihole
     helm:
       values: |
-        adminPassword: <path:secrets/data/pihole#admin-password>
+        adminPassword: "<vault:secret/data/pihole#admin-password>"
         persistence:
           enabled: true
           storageClassName: "local-path"

--- a/apps/postgres.yml
+++ b/apps/postgres.yml
@@ -14,7 +14,7 @@ spec:
         auth:
           database: rreading-glasses
           username: rreading-glasses
-          password: "<path:secrets/data/postgres#password>"
+          password: "<vault:secret/data/postgres#password>"
         primary:
           persistence:
             enabled: true

--- a/apps/qbittorrent.yml
+++ b/apps/qbittorrent.yml
@@ -6,41 +6,26 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/Jules-Recruiter/homelab-SRE-challenge' # This will be replaced by the actual repo URL
-    path: charts/vpn-app
-    targetRevision: HEAD
+    repoURL: 'https://bjw-s.github.io/helm-charts'
+    chart: qbittorrent
+    targetRevision: 15.0.1
     helm:
       values: |
-        application:
-          image:
-            repository: "linuxserver/qbittorrent"
-            tag: "latest"
-          name: "qbittorrent"
-          port: 8080
+        image:
+          repository: "linuxserver/qbittorrent"
+          tag: "latest"
 
-        gluetun:
-          vpn:
-            type: "openvpn"
-            provider: "private internet access"
-            region: "ca montreal"
-            credentials:
-              user: "<path:secret/data/qbittorrent#pia_username>"
-              password: "<path:secret/data/qbittorrent#pia_password>"
-
-        service:
-          type: ClusterIP
-          port: 8080
-
-        ingressRoute:
-          enabled: true
-          entryPoints:
-            - websecure
-          routes:
-            - match: Host(`qbittorrent.{{ domain_root }}`)
-              kind: Rule
-              services:
-                - name: qbittorrent
-                  port: 8080
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "qbittorrent.{{ domain_root }}"
+                paths:
+                  - path: /
+                    pathType: Prefix
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: qbittorrent

--- a/apps/radarr.yml
+++ b/apps/radarr.yml
@@ -6,41 +6,26 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/toxicoder/homelabeazy'
-    path: charts/vpn-app
-    targetRevision: HEAD
+    repoURL: 'https://bjw-s.github.io/helm-charts'
+    chart: radarr
+    targetRevision: 15.0.1
     helm:
       values: |
-        application:
-          image:
-            repository: "linuxserver/radarr"
-            tag: "latest"
-          name: "radarr"
-          port: 7878
+        image:
+          repository: "linuxserver/radarr"
+          tag: "latest"
 
-        gluetun:
-          vpn:
-            type: "openvpn"
-            provider: "private internet access"
-            region: "ca montreal"
-            credentials:
-              user: "<path:secret/data/radarr#pia_username>"
-              password: "<path:secret/data/radarr#pia_password>"
-
-        service:
-          type: ClusterIP
-          port: 7878
-
-        ingressRoute:
-          enabled: true
-          entryPoints:
-            - websecure
-          routes:
-            - match: Host(`radarr.{{ domain_root }}`)
-              kind: Rule
-              services:
-                - name: radarr
-                  port: 7878
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "radarr.{{ domain_root }}"
+                paths:
+                  - path: /
+                    pathType: Prefix
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: radarr

--- a/apps/sabnzbd.yml
+++ b/apps/sabnzbd.yml
@@ -6,41 +6,26 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/toxicoder/homelabeazy'
-    path: charts/vpn-app
-    targetRevision: HEAD
+    repoURL: 'https://bjw-s.github.io/helm-charts'
+    chart: sabnzbd
+    targetRevision: 15.0.1
     helm:
       values: |
-        application:
-          image:
-            repository: "linuxserver/sabnzbd"
-            tag: "latest"
-          name: "sabnzbd"
-          port: 8080
+        image:
+          repository: "linuxserver/sabnzbd"
+          tag: "latest"
 
-        gluetun:
-          vpn:
-            type: "openvpn"
-            provider: "private internet access"
-            region: "ca montreal"
-            credentials:
-              user: "<path:secret/data/sabnzbd#pia_username>"
-              password: "<path:secret/data/sabnzbd#pia_password>"
-
-        service:
-          type: ClusterIP
-          port: 8080
-
-        ingressRoute:
-          enabled: true
-          entryPoints:
-            - websecure
-          routes:
-            - match: Host(`sabnzbd.{{ domain_root }}`)
-              kind: Rule
-              services:
-                - name: sabnzbd
-                  port: 8080
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "sabnzbd.{{ domain_root }}"
+                paths:
+                  - path: /
+                    pathType: Prefix
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: sabnzbd

--- a/apps/sonarr.yml
+++ b/apps/sonarr.yml
@@ -6,41 +6,26 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/toxicoder/homelabeazy'
-    path: charts/vpn-app
-    targetRevision: HEAD
+    repoURL: 'https://bjw-s.github.io/helm-charts'
+    chart: sonarr
+    targetRevision: 15.0.1
     helm:
       values: |
-        application:
-          image:
-            repository: "linuxserver/sonarr"
-            tag: "latest"
-          name: "sonarr"
-          port: 8989
+        image:
+          repository: "linuxserver/sonarr"
+          tag: "latest"
 
-        gluetun:
-          vpn:
-            type: "openvpn"
-            provider: "private internet access"
-            region: "ca montreal"
-            credentials:
-              user: "<path:secret/data/sonarr#pia_username>"
-              password: "<path:secret/data/sonarr#pia_password>"
-
-        service:
-          type: ClusterIP
-          port: 8989
-
-        ingressRoute:
-          enabled: true
-          entryPoints:
-            - websecure
-          routes:
-            - match: Host(`sonarr.{{ domain_root }}`)
-              kind: Rule
-              services:
-                - name: sonarr
-                  port: 8989
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "sonarr.{{ domain_root }}"
+                paths:
+                  - path: /
+                    pathType: Prefix
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: sonarr

--- a/apps/wireguard.yml
+++ b/apps/wireguard.yml
@@ -6,9 +6,22 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/Jules-Recruiter/homelab-SRE-challenge'
-    path: charts/wireguard
-    targetRevision: HEAD
+    repoURL: 'https://geek-cookbook.github.io/charts/'
+    chart: wg-easy
+    targetRevision: 3.2.1
+    helm:
+      values: |
+        ingress:
+          main:
+            enabled: true
+            annotations:
+              traefik.ingress.kubernetes.io/router.entrypoints: websecure
+              traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+            hosts:
+              - host: "wg.{{ domain_root }}"
+                paths:
+                  - path: /
+                    pathType: Prefix
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: wireguard


### PR DESCRIPTION
- **Standardize Secret Syntax in ArgoCD Apps**
  - Replaced all instances of `path:secrets/data/...` with `vault:secret/data/...` in ArgoCD application manifests.

- **Update Helm Chart Sources**
  - Updated Helm chart `repoURL`s in ArgoCD application manifests to point to official or community-maintained repositories, removing personal forks and placeholder URLs.
  - Standardized the structure of the application manifests to align with the new chart versions.

- **Refine GitHub Actions Workflow**
  - Refactored the `.github/workflows/ci.yml` file to create a more organized and efficient CI pipeline.
  - Created distinct jobs for `lint`, `test-infra`, `test-python`, and `terraform-validate`.