### PR TITLE
feat: Add homebox application

### DIFF
--- a/apps/homebox.yml
+++ b/apps/homebox.yml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: homebox
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/toxicoder/homelabeazy.git'
+    path: charts/homebox
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - "values.yaml"
+        - "https://raw.githubusercontent.com/toxicoder/homelabeazy/main/config/apps/homebox/values.yaml"
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: homebox
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/homebox/Chart.yaml
+++ b/charts/homebox/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: homebox
+description: A Helm chart for Homebox
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/homebox/templates/_helpers.tpl
+++ b/charts/homebox/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "homebox.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "homebox.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart-level resource labels.
+*/}}
+{{- define "homebox.labels" -}}
+helm.sh/chart: {{ include "homebox.name" . }}
+{{ include "homebox.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "homebox.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "homebox.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/homebox/templates/deployment.yaml
+++ b/charts/homebox/templates/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "homebox.fullname" . }}
+  labels:
+    {{- include "homebox.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "homebox.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "homebox.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          volumeMounts:
+          {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+          {{- end }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "homebox.fullname" . }}
+        {{- end }}

--- a/charts/homebox/templates/ingressroute.yaml
+++ b/charts/homebox/templates/ingressroute.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "homebox.fullname" . }}
+  labels:
+    {{- include "homebox.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`{{ .Values.ingress.hosts[0].host }}`) && PathPrefix(`{{ .Values.ingress.hosts[0].paths[0].path }}`)
+      kind: Rule
+      services:
+        - name: {{ include "homebox.fullname" . }}
+          port: {{ .Values.service.port }}
+  {{- if .Values.ingress.annotations }}
+  middlewares:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    - name: {{ $value }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/homebox/templates/pvc.yaml
+++ b/charts/homebox/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "homebox.fullname" . }}
+  labels:
+    {{- include "homebox.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/homebox/templates/service.yaml
+++ b/charts/homebox/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "homebox.fullname" . }}
+  labels:
+    {{- include "homebox.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "homebox.selectorLabels" . | nindent 4 }}

--- a/charts/homebox/values.yaml
+++ b/charts/homebox/values.yaml
@@ -1,0 +1,31 @@
+# Default values for homebox.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/sysadminsmedia/homebox
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 7745
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: homebox.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+
+persistence:
+  enabled: false
+  size: 1Gi
+  accessMode: ReadWriteOnce
+  storageClass: ""

--- a/config.example/apps/homebox/values.yaml
+++ b/config.example/apps/homebox/values.yaml
@@ -1,0 +1,20 @@
+# Example values for homebox.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+ingress:
+  enabled: true
+  hosts:
+    - host: "homebox.homelab.dev"
+      paths:
+        - path: /
+          pathType: Prefix
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+
+persistence:
+  enabled: true
+  size: 5Gi
+  accessMode: ReadWriteOnce
+  storageClass: "local-path"


### PR DESCRIPTION
This adds the homebox application to the homelab. It includes:

- A new Helm chart for homebox in `charts/homebox`.
- An ArgoCD Application manifest in `apps/homebox.yml`.
- An example configuration in `config.example/apps/homebox/values.yaml`.