### PR TITLE
feat: Add Jackett application

### DIFF
--- a/apps/jackett.yml
+++ b/apps/jackett.yml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: jackett
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/toxicoder/homelabeazy.git'
+    path: charts/vpn-app
+    targetRevision: HEAD
+    helm:
+      values: |
+        application:
+          name: jackett
+          image:
+            repository: "linuxserver/jackett"
+            tag: "latest"
+          port: 9117
+
+        gluetun:
+          vpn:
+            type: "wireguard"
+            provider: "private internet access"
+            region: "ca montreal"
+            credentials:
+              user: "vault:secret/data/gluetun#username"
+              password: "vault:secret/data/gluetun#password"
+
+        ingress:
+          enabled: true
+          annotations:
+            traefik.ingress.kubernetes.io/router.entrypoints: websecure
+            traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+          hosts:
+            - host: "jackett.{{ domain_root }}"
+              paths:
+                - path: /
+                  pathType: Prefix
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: jackett
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Adds the Jackett application to the homelab.

Jackett is deployed using the local `vpn-app` Helm chart to ensure its traffic is routed through a VPN. The application is exposed via Traefik and secured with Authelia.