### PR TITLE
feat: Add kiwix application

### DIFF
--- a/apps/kiwix.yml
+++ b/apps/kiwix.yml
@@ -1,0 +1,23 @@
+apiVersion: "argoproj.io/v1alpha1"
+kind: "Application"
+metadata:
+  name: "kiwix"
+  namespace: "argocd"
+spec:
+  project: "default"
+  source:
+    repoURL: "https://github.com/toxicoder/hometable.git"
+    path: "charts/kiwix"
+    targetRevision: "HEAD"
+    helm:
+      valueFiles:
+        - "values.yaml"
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: "kiwix"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/kiwix/Chart.yaml
+++ b/charts/kiwix/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: kiwix
+description: A Helm chart for kiwix-serve
+type: application
+version: 0.1.0
+appVersion: "3.1.2"
+dependencies:
+  - name: common
+    version: 0.1.0
+    repository: file://../common

--- a/charts/kiwix/templates/_helpers.tpl
+++ b/charts/kiwix/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kiwix.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kiwix.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart-level resource labels.
+*/}}
+{{- define "kiwix.labels" -}}
+helm.sh/chart: {{ include "kiwix.name" . }}
+{{ include "kiwix.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kiwix.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kiwix.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kiwix/templates/deployment.yaml
+++ b/charts/kiwix/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          args:
+            - "/data/library.zim"
+          volumeMounts:
+          {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+          {{- end }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Chart.Name }}
+        {{- end }}

--- a/charts/kiwix/templates/ingressroute.yaml
+++ b/charts/kiwix/templates/ingressroute.yaml
@@ -1,0 +1,1 @@
+{{- include "common.ingressroute" . }}

--- a/charts/kiwix/templates/pvc.yaml
+++ b/charts/kiwix/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kiwix.fullname" . }}
+  labels:
+    {{- include "kiwix.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/kiwix/templates/service.yaml
+++ b/charts/kiwix/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "common.service" . }}

--- a/charts/kiwix/values.yaml
+++ b/charts/kiwix/values.yaml
@@ -1,0 +1,20 @@
+replicaCount: 1
+
+image:
+  repository: kiwix/kiwix-serve
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  host: kiwix.local
+
+persistence:
+  enabled: true
+  size: 10Gi
+  accessMode: ReadWriteOnce
+  storageClass: ""

--- a/config.example/apps/kiwix/values.yaml
+++ b/config.example/apps/kiwix/values.yaml
@@ -1,0 +1,20 @@
+replicaCount: 1
+
+image:
+  repository: kiwix/kiwix-serve
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  host: kiwix.local
+
+persistence:
+  enabled: true
+  size: 10Gi
+  accessMode: ReadWriteOnce
+  storageClass: ""


### PR DESCRIPTION
This commit adds the kiwix application to the homelab.

Kiwix is an offline reader for web content. This change adds the `kiwix-serve` application, which is a ZIM file server.

The following changes were made:
- A new Helm chart for `kiwix-serve` was created in `charts/kiwix`.
- An ArgoCD `Application` manifest was created in `apps/kiwix.yml`.
- Default configuration was added in `config.example/apps/kiwix/values.yaml`.