### PR TITLE
feat: Add linkwarden application

### DIFF
--- a/apps/linkwarden.yml
+++ b/apps/linkwarden.yml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: linkwarden
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/toxicoder/homelabeazy.git'
+    path: charts/linkwarden
+    targetRevision: HEAD
+    helm:
+      values: |
+        ingress:
+          enabled: true
+          annotations:
+            traefik.ingress.kubernetes.io/router.entrypoints: websecure
+            traefik.ingress.kubernetes.io/router.middlewares: authelia@kubernetescrd
+          hosts:
+            - host: "linkwarden.homelab.dev"
+              paths:
+                - path: /
+                  pathType: Prefix
+        persistence:
+          enabled: true
+          size: 5Gi
+        config:
+          database:
+            password: "<vault:secret/data/postgres#linkwarden_password>"
+          meilisearch:
+            apiKey: "<vault:secret/data/meilisearch#key>"
+          nextauth:
+            secret: "<vault:secret/data/linkwarden#nextauth_secret>"
+            url: "https://linkwarden.homelab.dev/api/v1/auth"
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: linkwarden
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/meilisearch.yml
+++ b/apps/meilisearch.yml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: meilisearch
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: 'https://meilisearch.github.io/meilisearch-kubernetes'
+    chart: meilisearch
+    targetRevision: 0.10.1
+    helm:
+      values: |
+        meilisearch:
+          masterKey: "<vault:secret/data/meilisearch#key>"
+        persistence:
+          enabled: true
+          size: 5Gi
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: meilisearch
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/postgres.yml
+++ b/apps/postgres.yml
@@ -15,7 +15,20 @@ spec:
           database: rreading-glasses
           username: rreading-glasses
           password: "<vault:secret/data/postgres#password>"
+          postgresPassword: "<vault:secret/data/postgres#postgres-password>"
         primary:
+          extraEnvVars:
+            - name: LINKWARDEN_DB_PASSWORD
+              value: "<vault:secret/data/postgres#linkwarden_password>"
+          initdb:
+            scripts:
+              "create-linkwarden-db.sh": |
+                #!/bin/bash
+                set -e
+                psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+                  CREATE USER linkwarden WITH PASSWORD '$LINKWARDEN_DB_PASSWORD';
+                  CREATE DATABASE linkwarden OWNER linkwarden;
+                EOSQL
           persistence:
             enabled: true
             size: 1Gi

--- a/charts/linkwarden/Chart.yaml
+++ b/charts/linkwarden/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: linkwarden
+description: A Helm chart for Linkwarden
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/linkwarden/templates/_helpers.tpl
+++ b/charts/linkwarden/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "linkwarden.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "linkwarden.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart-level resource labels.
+*/}}
+{{- define "linkwarden.labels" -}}
+helm.sh/chart: {{ include "linkwarden.name" . }}
+{{ include "linkwarden.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "linkwarden.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "linkwarden.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/linkwarden/templates/deployment.yaml
+++ b/charts/linkwarden/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "linkwarden.fullname" . }}
+  labels:
+    {{- include "linkwarden.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "linkwarden.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "linkwarden.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.config.database.user }}:{{ .Values.config.database.password }}@{{ .Values.config.database.host }}:{{ .Values.config.database.port }}/{{ .Values.config.database.database }}"
+            - name: MEILI_HOST
+              value: "http://{{ .Values.config.meilisearch.host }}:{{ .Values.config.meilisearch.port }}"
+            - name: MEILI_MASTER_KEY
+              value: "{{ .Values.config.meilisearch.apiKey }}"
+            - name: NEXTAUTH_SECRET
+              value: "{{ .Values.config.nextauth.secret }}"
+            - name: NEXTAUTH_URL
+              value: "{{ .Values.config.nextauth.url }}"
+          volumeMounts:
+          {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "linkwarden.fullname" . }}
+        {{- end }}

--- a/charts/linkwarden/templates/ingressroute.yaml
+++ b/charts/linkwarden/templates/ingressroute.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "linkwarden.fullname" . }}
+  labels:
+    {{- include "linkwarden.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`{{ .Values.ingress.hosts[0].host }}`) && PathPrefix(`{{ .Values.ingress.hosts[0].paths[0].path }}`)
+      kind: Rule
+      services:
+        - name: {{ include "linkwarden.fullname" . }}
+          port: {{ .Values.service.port }}
+  {{- if .Values.ingress.annotations }}
+  middlewares:
+    {{- range $key, $value := .Values.ingress.annotations }}
+    - name: {{ $value }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/linkwarden/templates/pvc.yaml
+++ b/charts/linkwarden/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "linkwarden.fullname" . }}
+  labels:
+    {{- include "linkwarden.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/linkwarden/templates/service.yaml
+++ b/charts/linkwarden/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "linkwarden.fullname" . }}
+  labels:
+    {{- include "linkwarden.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "linkwarden.selectorLabels" . | nindent 4 }}

--- a/charts/linkwarden/values.yaml
+++ b/charts/linkwarden/values.yaml
@@ -1,0 +1,48 @@
+# Default values for linkwarden.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/linkwarden/linkwarden
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: linkwarden.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+
+persistence:
+  enabled: false
+  size: 1Gi
+  accessMode: ReadWriteOnce
+  storageClass: ""
+  mountPath: /data/data
+
+# Linkwarden specific configuration
+config:
+  database:
+    host: "postgres.postgres.svc.cluster.local"
+    port: 5432
+    user: "linkwarden"
+    password: "" # This should be set from vault
+    database: "linkwarden"
+  meilisearch:
+    host: "meilisearch-service.meilisearch.svc.cluster.local"
+    port: 7700
+    apiKey: "" # This should be set from vault
+  nextauth:
+    secret: "" # This should be set from vault
+    url: "http://linkwarden.local/api/v1/auth"


### PR DESCRIPTION
This commit adds the Linkwarden application to the homelab.

It includes:
- A new Helm chart for Linkwarden.
- An ArgoCD application manifest for Linkwarden.
- An ArgoCD application manifest for Meilisearch, which is a dependency of Linkwarden.
- An update to the PostgreSQL application to create a new database and user for Linkwarden.