### PR TITLE
feat: Add gitleaks scan to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
         with:
           working_directory: infrastructure/proxmox
 
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        with:
+          config_path: .gitea/gitleaks.toml
+          report_format: json
+          report_path: gitleaks-report.json
+
   ansible-molecule:
     name: Ansible Molecule
     runs-on: ubuntu-latest


### PR DESCRIPTION
Integrates gitleaks scanning into the CI/CD pipeline to automatically detect secrets on every push and pull request.

- Adds a new 'gitleaks' job to the .github/workflows/ci.yml file.
- Configures the job to use the existing .gitea/gitleaks.toml configuration.
- The scan will fail if secrets are detected, preventing them from being merged.
- The full git history is fetched to ensure a comprehensive scan.