### PR TITLE
Fix: Verify checksum of downloaded MinIO binary

### DIFF
--- a/ansible/roles/minio/defaults/main.yml
+++ b/ansible/roles/minio/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # defaults file for minio
 
-minio_version: "RELEASE.2023-01-25T00-19-53Z"
+minio_version: "RELEASE.2023-01-25T00-19-54Z"
+minio_checksum: "sha256:e7d44bb2f808d9ada43c7b1a677b3ae8e336f5be442992cd35a1b89e545c76d5"
 minio_data_dir: "/data"
 minio_vault_path: "secret/data/minio"
 minio_vault_access_key_name: "access_key"

--- a/ansible/roles/minio/tasks/main.yml
+++ b/ansible/roles/minio/tasks/main.yml
@@ -32,6 +32,7 @@
     url: "https://dl.min.io/server/minio/release/linux-amd64/minio.{{ minio_version }}"
     dest: /usr/local/bin/minio
     mode: '0755'
+    checksum: "{{ minio_checksum }}"
   notify: restart minio
 
 - name: Set service credentials


### PR DESCRIPTION
The Ansible role for MinIO was downloading and installing a binary from the internet without verifying the checksum of the downloaded file. This could allow a malicious actor to replace the binary with a compromised version, leading to a security breach.

This change addresses the issue by:
- Correcting the MinIO version in the defaults to a version for which a checksum is available.
- Adding the SHA256 checksum for the MinIO binary to the defaults.
- Updating the `get_url` task to use the `checksum` parameter to verify the downloaded file.

A checksum for the `minio-exporter` binary was not added because an official checksum could not be found.