### PR TITLE
feat(pfsense): Restrict firewall rules to least privilege

### DIFF
--- a/ansible/roles/pfsense/tasks/main.yml
+++ b/ansible/roles/pfsense/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# tasks file for pfsense
+- name: Allow HTTP and HTTPS traffic from the service network to the internet
+  pfsense:
+    rule:
+      action: pass
+      interface: lan
+      protocol: tcp
+      source:
+        network: "{{ service_network }}"
+      destination:
+        network: any
+      destination_port:
+        - 80
+        - 443
+      log: true
+  tags:
+    - pfsense


### PR DESCRIPTION
This change introduces a more restrictive firewall rule for the pfSense role, following the principle of least privilege.

Previously, the firewall rule allowed all traffic from the service network to the internet. This has been changed to only allow HTTP (port 80) and HTTPS (port 443) traffic.

This reduces the attack surface and limits the potential for unauthorized access.

The `pfsense` role was also created as it was missing from the repository.