### PR TITLE
Fix CI errors in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
           go-version: '1.22'
 
       - name: Run Go tests
-        working-directory: ./infrastructure/proxmox
-        run: go test -v ./test/...
+        working-directory: ./infrastructure/proxmox/test
+        run: go test -v ./...
 
   test-python:
     name: Test Python
@@ -78,7 +78,6 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install -r tools/homelab-importer/requirements.txt
           pip install coverage
       - name: Run Python tests with coverage
         run: |

--- a/apps/bitwarden.yml
+++ b/apps/bitwarden.yml
@@ -46,4 +46,4 @@ spec:
       selfHeal: true
       prune: true
     syncOptions:
-    - CreateNamespace=true
+      - CreateNamespace=true

--- a/apps/pihole.yml
+++ b/apps/pihole.yml
@@ -24,4 +24,4 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-    - CreateNamespace=true
+      - CreateNamespace=true


### PR DESCRIPTION
This commit fixes three errors in the CI workflows:

1.  Corrected indentation in `apps/pihole.yml` and `apps/bitwarden.yml` to fix the YAML linting errors.
2.  Fixed the Go test command in the `test-infra` job by pointing it to the correct directory containing the go module.
3.  Removed the `pip install` command that was pointing to a non-existent `requirements.txt` file for the `homelab-importer` tool.