### PR TITLE
fix(ci): Install OpenTofu in the test-infra job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Setup OpenTofu
+        uses: opentofu/setup-tofu@v1
+        with:
+          tofu_version: latest
+
       - name: Run Go tests
         working-directory: ./infrastructure/proxmox/test
         run: go test -v ./...


### PR DESCRIPTION
The `test-infra` job was failing because the `tofu` executable was not found in the PATH. This change adds a step to the workflow to install OpenTofu using the `opentofu/setup-tofu` GitHub Action.

This ensures that the `tofu` binary is available when the Go tests are run, resolving the "executable file not found in $PATH" error.