### PR TITLE
Fix(ci): Correct opentofu/setup-tofu action name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           go-version: '1.22'
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-tofu@v1
+        uses: opentofu/setup-opentofu@v1
         with:
           tofu_version: latest
 


### PR DESCRIPTION
The CI workflow was failing because the `opentofu/setup-tofu` action could not be found. This was due to a typo in the action name. The correct action name is `opentofu/setup-opentofu`.

This commit corrects the action name in the `ci.yml` workflow file to `opentofu/setup-opentofu@v1`, which will resolve the CI failure.