### PR TITLE
fix: Correctly set SMBIOS UUID for stealth-vm

### DIFF
--- a/infrastructure/proxmox/main.tf
+++ b/infrastructure/proxmox/main.tf
@@ -61,5 +61,5 @@ module "stealth-vm" {
   stealth_vm_real_mac      = var.stealth_vm_real_mac
   stealth_vm_gpu_pci_id    = var.stealth_vm_gpu_pci_id
   stealth_vm_hv_vendor_id  = var.stealth_vm_hv_vendor_id
-  stealth_vm_smbios_uuid   = var.stealth_vm_smbios_uuid
+  smbios_uuid              = var.stealth_vm_smbios_uuid
 }

--- a/infrastructure/stealth-vm/main.tf
+++ b/infrastructure/stealth-vm/main.tf
@@ -31,7 +31,7 @@ resource "proxmox_vm_qemu" "stealth_vm" {
   }
 
   # QEMU Args
-  args = "-cpu host,-hypervisor,+kvm_pv_unhalt,+kvm_pv_eoi,hv_spinlocks=0x1fff,hv_vapic,hv_time,hv_reset,hv_vpindex,hv_runtime,hv_relaxed,kvm=off,hv_vendor_id=${var.stealth_vm_hv_vendor_id}"
+  args = "-cpu host,-hypervisor,+kvm_pv_unhalt,+kvm_pv_eoi,hv_spinlocks=0x1fff,hv_vapic,hv_time,hv_reset,hv_vpindex,hv_runtime,hv_relaxed,kvm=off,hv_vendor_id=${var.stealth_vm_hv_vendor_id} -smbios type=1,uuid=${var.smbios_uuid}"
 
   # SMBIOS
   # smbios {

--- a/infrastructure/stealth-vm/variables.tf
+++ b/infrastructure/stealth-vm/variables.tf
@@ -98,6 +98,12 @@ variable "stealth_vm_hv_vendor_id" {
   default     = "amd"
 }
 
+variable "smbios_uuid" {
+  description = "The SMBIOS UUID for the stealth VM."
+  type        = string
+  default     = ""
+}
+
 # ----------------------------------------------------------------------------------------------------------------------
 # Network Configuration
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The `stealth-vm` module was failing validation because it was being passed an unexpected argument, `stealth_vm_smbios_uuid`.

This change corrects the issue by:
1.  Adding a `smbios_uuid` variable to the `stealth-vm` module.
2.  Updating the module call to pass `smbios_uuid` instead of `stealth_vm_smbios_uuid`.
3.  Using the `args` parameter in the `proxmox_vm_qemu` resource to set the SMBIOS UUID, as the installed version of the `telmate/proxmox` provider does not support the `smbios` block.