### PR TITLE
Fix a large number of ansible-lint errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ gitleaks-report.json
 
 # Private configuration
 /private/
+
+# Ansible collections
+ansible/.ansible/

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+collections_path = ./ansible/.ansible/collections:./ansible_collections
+roles_path       = ./ansible/roles
+inventory        = ./ansible/inventory/dynamic_inventory/proxmox_inventory.py

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -83,7 +83,7 @@ The variables that can be passed to this role and a brief description about them
 | `k3s_ssh_user` | `ansible` | The SSH user for the VMs. |
 | `k3s_ssh_private_key_file` | `~/.ssh/id_rsa` | The private SSH key file for the VMs. |
 | `k3s_ssh_public_key_file` | `~/.ssh/id_rsa.pub` | The public SSH key file for the VMs. |
-| `k3s_version` | `v1.28.4+k3s1` | The k3s version to install. |
+| `k3s_cluster_version` | `v1.28.4+k3s1` | The k3s version to install. |
 | `k3s_cluster_name` | `k3s_cluster` | The name of the k3s cluster. |
 | `k3s_cluster_domain` | `k3s.local` | The domain for the k3s cluster. |
 | `k3s_cluster_cidr` | `10.42.0.0/16` | The pod network CIDR. |

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,4 +1,0 @@
-[defaults]
-collections_path = ./.ansible/collections
-roles_path       = ./roles
-inventory        = ./inventory/dynamic_inventory/proxmox_inventory.py

--- a/ansible/playbooks/main.yml
+++ b/ansible/playbooks/main.yml
@@ -4,9 +4,11 @@
   gather_facts: false
 
   roles:
-    - role: homelab_config
-    - role: k3s_cluster
-    - role: traefik
-    - role: efk_stack
-    - role: core_services
-    - role: applications
+    - homelab_config
+    - k3s_cluster
+    - traefik
+    - efk_stack
+    - applications
+
+- name: Run core services playbook
+  ansible.builtin.import_playbook: ../../scripts/core-services.yml

--- a/ansible/playbooks/secure-gen.yml
+++ b/ansible/playbooks/secure-gen.yml
@@ -3,7 +3,9 @@
   gather_facts: false
   tasks:
     - name: Run secure_gen script
-      ansible.builtin.command: "python3 {{ secure_gen_role_path }}/files/secure-gen --config-file ../../../../private/config.yml"
+      ansible.builtin.command: >
+        python3 {{ secure_gen_role_path }}/files/secure-gen
+        --config-file ../../../../private/config.yml
       register: secure_gen_result
       changed_when: secure_gen_result.rc != 0
       args:

--- a/ansible/playbooks/setup_core_apps.yml
+++ b/ansible/playbooks/setup_core_apps.yml
@@ -5,4 +5,6 @@
     - role: config
       vars:
         config_maps_dir: "{{ inventory_dir }}/../configmaps"
-    - core_apps
+
+- name: Run applications playbook
+  ansible.builtin.import_playbook: ../../scripts/applications.yml

--- a/ansible/playbooks/test_synology_mock.yml
+++ b/ansible/playbooks/test_synology_mock.yml
@@ -1,8 +1,6 @@
 - name: Test Synology Module
   hosts: localhost
   gather_facts: false
-  collections:
-    - synology.nas
   vars:
     ansible_host: "mock-synology-api"
     ansible_port: 8000
@@ -30,7 +28,7 @@
       register: create_user_result
 
     - name: Verify user creation
-      assert:
+      ansible.builtin.assert:
         that:
           - create_user_result.changed
 
@@ -50,7 +48,7 @@
       register: create_user_idempotent_result
 
     - name: Verify user creation idempotency
-      assert:
+      ansible.builtin.assert:
         that:
           - not create_user_idempotent_result.changed
 
@@ -67,7 +65,7 @@
       register: delete_user_result
 
     - name: Verify user deletion
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_user_result.changed
 
@@ -86,7 +84,7 @@
       register: create_group_result
 
     - name: Verify group creation
-      assert:
+      ansible.builtin.assert:
         that:
           - create_group_result.changed
 
@@ -103,7 +101,7 @@
       register: delete_group_result
 
     - name: Verify group deletion
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_group_result.changed
 
@@ -120,7 +118,7 @@
       register: create_folder_result
 
     - name: Verify folder creation
-      assert:
+      ansible.builtin.assert:
         that:
           - create_folder_result.changed
 
@@ -137,6 +135,6 @@
       register: delete_folder_result
 
     - name: Verify folder deletion
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_folder_result.changed

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,6 +4,7 @@ collections:
   - name: community.hashi_vault
     version: "4.1.0"
   - name: community.general
+  - name: pfsensible.core
 
 roles:
   - name: homepage

--- a/ansible/roles/asuswrt/tasks/main.yml
+++ b/ansible/roles/asuswrt/tasks/main.yml
@@ -3,78 +3,78 @@
 # ==============================================================================
 - name: Check hostname
   ansible.builtin.raw: nvram get odmpid
-  register: odmpid_check
+  register: asuswrt_odmpid_check
   changed_when: false
 
 - name: Set hostname
   ansible.builtin.raw: nvram set odmpid={{ asuswrt_hostname }}
-  when: odmpid_check.stdout != asuswrt_hostname
+  when: asuswrt_odmpid_check.stdout != asuswrt_hostname
+  changed_when: true
   notify: commit_nvram_changes
 
 - name: Check sshd enabled
   ansible.builtin.raw: nvram get sshd_enable
-  register: sshd_enable_check
+  register: asuswrt_sshd_enable_check
   changed_when: false
 
 - name: Set sshd enabled
   ansible.builtin.raw: nvram set sshd_enable=1
-  when: sshd_enable_check.stdout != "1"
+  when: asuswrt_sshd_enable_check.stdout != "1"
+  changed_when: true
   notify: commit_nvram_changes
 
 - name: Check sshd wan access
   ansible.builtin.raw: nvram get sshd_wan
-  register: sshd_wan_check
+  register: asuswrt_sshd_wan_check
   changed_when: false
 
 - name: Set sshd wan access
   ansible.builtin.raw: nvram set sshd_wan=1
-  when: sshd_wan_check.stdout != "1"
+  when: asuswrt_sshd_wan_check.stdout != "1"
+  changed_when: true
   notify: commit_nvram_changes
 
 # ==============================================================================
 # Wi-Fi Configuration
 # ==============================================================================
 - name: Configure wifi settings
-  community.general.nvram:
-    name: "{{ item.nvram_prefix }}_ssid"
-    value: "{{ item.ssid }}"
+  ansible.builtin.raw: "nvram set {{ item.nvram_prefix }}_ssid='{{ item.ssid }}'"
   loop: "{{ asuswrt_wifi_config }}"
+  changed_when: true
   notify: restart_wireless
 
 - name: Configure wifi password
-  community.general.nvram:
-    name: "{{ item.nvram_prefix }}_wpa_psk"
-    value: "{{ item.password }}"
+  ansible.builtin.raw: "nvram set {{ item.nvram_prefix }}_wpa_psk='{{ item.password }}'"
   loop: "{{ asuswrt_wifi_config }}"
+  changed_when: true
   notify: restart_wireless
 
 - name: Configure wifi channel
-  community.general.nvram:
-    name: "{{ item.nvram_prefix }}_channel"
-    value: "{{ item.channel }}"
+  ansible.builtin.raw: "nvram set {{ item.nvram_prefix }}_channel='{{ item.channel }}'"
   loop: "{{ asuswrt_wifi_config }}"
+  changed_when: true
   notify: restart_wireless
-
 # ==============================================================================
 # DHCP Static Leases
 # =================================================.
 - name: Get current DHCP static list
   ansible.builtin.raw: "nvram get dhcp_staticlist"
-  register: dhcp_staticlist_raw
+  register: asuswrt_dhcp_staticlist_raw
   changed_when: false
   check_mode: false
 
 - name: Set desired DHCP static list
   ansible.builtin.set_fact:
-    desired_dhcp_staticlist: >-
+    asuswrt_desired_dhcp_staticlist: >-
       {{ asuswrt_dhcp_static_leases | map(attribute='mac') |
       zip(asuswrt_dhcp_static_leases | map(attribute='ip')) |
       zip(asuswrt_dhcp_static_leases | map(attribute='hostname')) |
       map('flatten') | map('join', '>') | join(' ') }}
 
 - name: Manage DHCP static list
-  ansible.builtin.raw: "nvram set dhcp_staticlist='{{ desired_dhcp_staticlist }}'"
-  when: dhcp_staticlist_raw.stdout != desired_dhcp_staticlist
+  ansible.builtin.raw: "nvram set dhcp_staticlist='{{ asuswrt_desired_dhcp_staticlist }}'"
+  when: asuswrt_dhcp_staticlist_raw.stdout != asuswrt_desired_dhcp_staticlist
+  changed_when: true
   notify: commit_nvram_changes
 
 # ==============================================================================
@@ -82,13 +82,13 @@
 # ==============================================================================
 - name: Get current port forwarding list
   ansible.builtin.raw: "nvram get vts_rulelist"
-  register: vts_rulelist_raw
+  register: asuswrt_vts_rulelist_raw
   changed_when: false
   check_mode: false
 
 - name: Set desired port forwarding list
   ansible.builtin.set_fact:
-    desired_vts_rulelist: >-
+    asuswrt_desired_vts_rulelist: >-
       {{ asuswrt_port_forwards | map(attribute='description') |
       zip(asuswrt_port_forwards | map(attribute='external_port')) |
       zip(asuswrt_port_forwards | map(attribute='internal_ip')) |
@@ -97,6 +97,7 @@
       map('flatten') | map('join', '>') | join('<') }}
 
 - name: Manage port forwarding list
-  ansible.builtin.raw: "nvram set vts_rulelist='{{ desired_vts_rulelist }}'"
-  when: vts_rulelist_raw.stdout != desired_vts_rulelist
+  ansible.builtin.raw: "nvram set vts_rulelist='{{ asuswrt_desired_vts_rulelist }}'"
+  when: asuswrt_vts_rulelist_raw.stdout != asuswrt_desired_vts_rulelist
+  changed_when: true
   notify: commit_nvram_changes

--- a/ansible/roles/config/templates/main.yml.j2
+++ b/ansible/roles/config/templates/main.yml.j2
@@ -16,7 +16,7 @@ data:
   proxmox_storage: "{{ proxmox_storage }}"
   proxmox_bridge: "{{ proxmox_bridge }}"
   pm_api_url: "{{ pm_api_url }}"
-  k3s_version: "{{ k3s_version }}"
+  k3s_version: "{{ k3s_cluster_version }}"
   k3s_master_count: "{{ k3s_master_count }}"
   k3s_worker_count: "{{ k3s_worker_count }}"
   k3s_vm_memory: "{{ k3s_vm_memory }}"

--- a/ansible/roles/consul/tasks/main.yml
+++ b/ansible/roles/consul/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.unarchive:
     src: "/tmp/consul_{{ consul_version }}_linux_amd64.zip"
     dest: "/usr/local/bin"
-    remote_src: yes
+    remote_src: true
     creates: /usr/local/bin/consul
 
 - name: Configure Consul
@@ -21,4 +21,4 @@
   ansible.builtin.systemd:
     name: consul
     state: started
-    enabled: yes
+    enabled: true

--- a/ansible/roles/efk_stack/meta/main.yml
+++ b/ansible/roles/efk_stack/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   license: MIT
   min_ansible_version: "2.12"
   platforms:
-    - name: Generic
+    - name: GenericLinux
       versions:
         - all
   galaxy_tags:

--- a/ansible/roles/efk_stack/tasks/main.yml
+++ b/ansible/roles/efk_stack/tasks/main.yml
@@ -1,24 +1,24 @@
 - name: Install ECK CRDs
-  k8s:
+  kubernetes.core.k8s:
     src: https://download.elastic.co/downloads/eck/3.0.0/crds.yaml
     state: present
 
 - name: Install ECK Operator
-  k8s:
+  kubernetes.core.k8s:
     src: https://download.elastic.co/downloads/eck/3.0.0/operator.yaml
     state: present
 
 - name: Create Elasticsearch cluster
-  k8s:
+  kubernetes.core.k8s:
     template: elasticsearch.yml.j2
     state: present
 
 - name: Create Kibana instance
-  k8s:
+  kubernetes.core.k8s:
     template: kibana.yml.j2
     state: present
 
 - name: Create Fluentd DaemonSet
-  k8s:
+  kubernetes.core.k8s:
     template: fluentd.yml.j2
     state: present

--- a/ansible/roles/google_java_format/tasks/main.yml
+++ b/ansible/roles/google_java_format/tasks/main.yml
@@ -1,7 +1,10 @@
 - name: Download google-java-format
   vars:
     google_java_format_version: "1.15.0"
-    google_java_format_url: "https://github.com/google/google-java-format/releases/download/google-java-format-{{ google_java_format_version }}/google-java-format-{{ google_java_format_version }}-all-deps.jar"
+    google_java_format_url: >-
+      https://github.com/google/google-java-format/releases/download/google-java-format-{{
+      google_java_format_version }}/google-java-format-{{
+      google_java_format_version }}-all-deps.jar
   ansible.builtin.get_url:
     url: "{{ google_java_format_url }}"
     dest: /usr/local/bin/google-java-format.jar

--- a/ansible/roles/homelab_config/tasks/main.yml
+++ b/ansible/roles/homelab_config/tasks/main.yml
@@ -10,7 +10,9 @@
 
 - name: Combine common and environment-specific configurations
   ansible.builtin.set_fact:
-    homelab_config_vars: "{{ config_file.common | combine(config_file[homelab_config_env] | default({}), recursive=True) }}"
+    homelab_config_vars: >-
+      {{ config_file.common
+      | combine(config_file[homelab_config_env] | default({}), recursive=True) }}
 
 - name: Create configmaps directory
   ansible.builtin.file:
@@ -22,6 +24,7 @@
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ config_maps_dir }}/{{ item.dest }}"
+    mode: '0644'
   with_items:
     - { src: 'main.yml.j2', dest: 'main-configmap.yml' }
 

--- a/ansible/roles/k3s_cluster/README.md
+++ b/ansible/roles/k3s_cluster/README.md
@@ -7,7 +7,7 @@ This role installs a k3s cluster.
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```yaml
-k3s_version: "v1.29.3+k3s1"
+k3s_cluster_version: "v1.29.3+k3s1"
 ```
 
 ## Dependencies

--- a/ansible/roles/k3s_cluster/defaults/main.yml
+++ b/ansible/roles/k3s_cluster/defaults/main.yml
@@ -1,2 +1,2 @@
 # defaults file for k3s_cluster role
-k3s_version: "v1.29.3+k3s1"
+k3s_cluster_version: "v1.29.3+k3s1"

--- a/ansible/roles/k3s_cluster/tasks/install_master.yml
+++ b/ansible/roles/k3s_cluster/tasks/install_master.yml
@@ -8,7 +8,7 @@
 - name: Install k3s server
   ansible.builtin.command: "/tmp/k3s-install.sh"
   environment:
-    INSTALL_K3S_VERSION: "{{ k3s_version }}"
+    INSTALL_K3S_VERSION: "{{ k3s_cluster_version }}"
   delegate_to: "{{ item }}"
   args:
     creates: /usr/local/bin/k3s

--- a/ansible/roles/k3s_cluster/tasks/install_worker.yml
+++ b/ansible/roles/k3s_cluster/tasks/install_worker.yml
@@ -7,7 +7,7 @@
 - name: Install k3s agent
   ansible.builtin.command: "/tmp/k3s-install.sh"
   environment:
-    INSTALL_K3S_VERSION: "{{ k3s_version }}"
+    INSTALL_K3S_VERSION: "{{ k3s_cluster_version }}"
     K3S_URL: "https://{{ groups['k3s_masters'][0] }}:6443"
     K3S_TOKEN: "{{ lookup('community.hashi_vault.vault_read', 'secret/passwords/k3s_join_token')['data']['password'] }}"
   args:

--- a/ansible/roles/k3s_cluster/tasks/main.yml
+++ b/ansible/roles/k3s_cluster/tasks/main.yml
@@ -1,11 +1,7 @@
-- name: Deploy k3s cluster
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    - name: Install k3s master(s)
-      include_tasks: install_master.yml
-      loop: "{{ groups['k3s_masters'] }}"
+- name: Install k3s master(s)
+  ansible.builtin.include_tasks: install_master.yml
+  loop: "{{ groups['k3s_masters'] }}"
 
-    - name: Install k3s worker(s)
-      include_tasks: install_worker.yml
-      loop: "{{ groups['k3s_workers'] }}"
+- name: Install k3s worker(s)
+  ansible.builtin.include_tasks: install_worker.yml
+  loop: "{{ groups['k3s_workers'] }}"

--- a/ansible/roles/minio/tasks/main.yml
+++ b/ansible/roles/minio/tasks/main.yml
@@ -6,20 +6,20 @@
   register: minio_credentials
 
 - name: Create minio group
-  group:
+  ansible.builtin.group:
     name: minio
     state: present
 
 - name: Create minio user
-  user:
+  ansible.builtin.user:
     name: minio
     group: minio
     home: "{{ minio_data_dir }}"
-    create_home: yes
+    create_home: true
     shell: /bin/bash
 
 - name: Create data directory
-  file:
+  ansible.builtin.file:
     path: "{{ minio_data_dir }}"
     state: directory
     owner: minio
@@ -35,35 +35,37 @@
   notify: restart minio
 
 - name: Set service credentials
-  set_fact:
-    service_user: "{{ minio_credentials.data[minio_vault_access_key_name] }}"
-    service_password: "{{ minio_credentials.data[minio_vault_secret_key_name] }}"
+  ansible.builtin.set_fact:
+    minio_service_user: "{{ minio_credentials.data[minio_vault_access_key_name] }}"
+    minio_service_password: "{{ minio_credentials.data[minio_vault_secret_key_name] }}"
   no_log: true
 
 - name: Create systemd service file
   ansible.builtin.template:
     src: minio.service.j2
     dest: /etc/systemd/system/minio.service
+    mode: '0644'
   notify: restart minio
 
 - name: Start and enable minio service
   ansible.builtin.systemd:
     name: minio
     state: started
-    enabled: yes
-    daemon_reload: yes
+    enabled: true
+    daemon_reload: true
 
 - name: Deploy MinIO ServiceMonitor
   kubernetes.core.k8s:
     state: present
-    apply: yes
+    apply: true
     definition: "{{ lookup('template', 'minio-servicemonitor.yml.j2') | from_yaml }}"
 
 - name: Download and install minio exporter binary
-  unarchive:
-    src: "https://github.com/prometheus/minio-exporter/releases/download/v0.0.12/minio-exporter-0.0.12.linux-amd64.tar.gz"
+  ansible.builtin.unarchive:
+    src: >-
+      https://github.com/prometheus/minio-exporter/releases/download/v0.0.12/minio-exporter-0.0.12.linux-amd64.tar.gz
     dest: /usr/local/bin
-    remote_src: yes
+    remote_src: true
     extra_opts: [--strip-components=1]
     creates: /usr/local/bin/minio-exporter
   notify: restart minio-exporter
@@ -72,11 +74,12 @@
   ansible.builtin.template:
     src: minio-exporter.service.j2
     dest: /etc/systemd/system/minio-exporter.service
+    mode: '0644'
   notify: restart minio-exporter
 
 - name: Start and enable minio-exporter service
   ansible.builtin.systemd:
     name: minio-exporter
     state: started
-    enabled: yes
-    daemon_reload: yes
+    enabled: true
+    daemon_reload: true

--- a/ansible/roles/minio/templates/minio-exporter.service.j2
+++ b/ansible/roles/minio/templates/minio-exporter.service.j2
@@ -8,8 +8,8 @@ User=minio
 Group=minio
 ExecStart=/usr/local/bin/minio-exporter \
   --minio.server={{ minio_url }} \
-  --minio.access-key={{ service_user }} \
-  --minio.secret-key={{ service_password }}
+  --minio.access-key={{ minio_service_user }} \
+  --minio.secret-key={{ minio_service_password }}
 Restart=always
 
 [Install]

--- a/ansible/roles/minio/templates/minio.service.j2
+++ b/ansible/roles/minio/templates/minio.service.j2
@@ -7,8 +7,8 @@ After=network-online.target
 [Service]
 User=minio
 Group=minio
-Environment="MINIO_ROOT_USER={{ service_user }}"
-Environment="MINIO_ROOT_PASSWORD={{ service_password }}"
+Environment="MINIO_ROOT_USER={{ minio_service_user }}"
+Environment="MINIO_ROOT_PASSWORD={{ minio_service_password }}"
 ExecStart=/usr/local/bin/minio server {{ minio_data_dir }}
 
 [Install]

--- a/ansible/roles/minio/tests/test.yml
+++ b/ansible/roles/minio/tests/test.yml
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: MIT-0
-- hosts: localhost
+- name: Apply minio role
+  hosts: localhost
   remote_user: root
   roles:
     - minio
 
 - name: Minio placeholder test
-  ansible.builtin.debug:
-    msg: "This is a placeholder test for the Minio role."
+  hosts: localhost
+  tasks:
+    - name: Placeholder debug task
+      ansible.builtin.debug:
+        msg: "This is a placeholder test for the Minio role."

--- a/ansible/roles/minio/vars/main.yml
+++ b/ansible/roles/minio/vars/main.yml
@@ -1,3 +1,2 @@
 # SPDX-License-Identifier: MIT-0
----
 # vars file for minio

--- a/ansible/roles/pfsense/tasks/main.yml
+++ b/ansible/roles/pfsense/tasks/main.yml
@@ -1,17 +1,16 @@
 # tasks file for pfsense
 - name: Allow HTTP and HTTPS traffic from the service network to the internet
-  pfsense:
-    rule:
-      action: pass
-      interface: lan
-      protocol: tcp
-      source:
-        network: "{{ service_network }}"
-      destination:
-        network: any
-      destination_port:
-        - 80
-        - 443
-      log: true
+  pfsensible.core.pfsense_rule:
+    action: pass
+    interface: lan
+    protocol: tcp
+    source:
+      network: "{{ service_network }}"
+    destination:
+      network: any
+    destination_port:
+      - 80
+      - 443
+    log: true
   tags:
     - pfsense

--- a/ansible/roles/proxmox_host/meta/main.yml
+++ b/ansible/roles/proxmox_host/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   license: MIT
   min_ansible_version: "2.9"
   platforms:
-    - name: Proxmox
+    - name: GenericLinux
       versions:
         - all
   galaxy_tags:

--- a/ansible/roles/python_base/defaults/main.yml
+++ b/ansible/roles/python_base/defaults/main.yml
@@ -1,2 +1,2 @@
 # defaults file for python-base
-python_venv_path: /opt/python-venv
+python_base_venv_path: /opt/python-venv

--- a/ansible/roles/python_base/tasks/main.yml
+++ b/ansible/roles/python_base/tasks/main.yml
@@ -5,5 +5,5 @@
 
 - name: Create virtual environment
   ansible.builtin.command:
-    cmd: "python3 -m venv {{ python_venv_path }}"
-    creates: "{{ python_venv_path }}/bin/activate"
+    cmd: "python3 -m venv {{ python_base_venv_path }}"
+    creates: "{{ python_base_venv_path }}/bin/activate"

--- a/ansible/roles/secure_gen/README.md
+++ b/ansible/roles/secure_gen/README.md
@@ -7,7 +7,7 @@ This role installs the secure_gen tool.
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```yaml
-python_venv_path: /opt/secure_gen
+secure_gen_venv_path: /opt/secure_gen
 ```
 
 The path to the python virtual environment where the tool will be installed.

--- a/ansible/roles/secure_gen/defaults/main.yml
+++ b/ansible/roles/secure_gen/defaults/main.yml
@@ -1,2 +1,2 @@
 # defaults file for secure_gen role
-python_venv_path: /opt/secure_gen
+secure_gen_venv_path: /opt/secure_gen

--- a/ansible/roles/secure_gen/tasks/main.yml
+++ b/ansible/roles/secure_gen/tasks/main.yml
@@ -4,10 +4,10 @@
       - hvac
       - cryptography
       - python-gnupg
-    virtualenv: "{{ python_venv_path }}"
+    virtualenv: "{{ secure_gen_venv_path }}"
 
 - name: Copy secure_gen tool
   ansible.builtin.copy:
     src: secure_gen
-    dest: "{{ python_venv_path }}/bin/secure_gen"
+    dest: "{{ secure_gen_venv_path }}/bin/secure_gen"
     mode: '0755'

--- a/ansible/roles/vault/tasks/main.yml
+++ b/ansible/roles/vault/tasks/main.yml
@@ -29,7 +29,7 @@
     namespace: vault
     label_selectors:
       - app.kubernetes.io/name=vault
-    wait: yes
+    wait: true
     wait_condition:
       type: Ready
       status: "True"
@@ -52,14 +52,16 @@
   ansible.builtin.command:
     cmd: "ansible-vault encrypt_string"
     stdin: "{{ vault_credentials | to_nice_yaml }}"
-  register: encrypted_content
+  register: vault_encrypted_content
+  changed_when: false
   no_log: true
   delegate_to: localhost
 
 - name: Store encrypted vault keys
   ansible.builtin.copy:
-    content: "{{ encrypted_content.stdout }}"
+    content: "{{ vault_encrypted_content.stdout }}"
     dest: "{{ playbook_dir }}/.vault_keys.yml"
+    mode: '0600'
   delegate_to: localhost
   no_log: true
 

--- a/ansible/roles/vault_pki/tasks/main.yml
+++ b/ansible/roles/vault_pki/tasks/main.yml
@@ -11,7 +11,7 @@
     engine_mount_point: pki
     common_name: "{{ domain_root }}"
     ttl: "87600h"
-  register: root_ca
+  register: vault_pki_root_ca
 
 - name: Create Traefik role
   community.hashi_vault.vault_pki_role:
@@ -19,5 +19,5 @@
     name: traefik
     allowed_domains:
       - "{{ domain_root }}"
-    allow_subdomains: yes
+    allow_subdomains: true
     max_ttl: "8760h"

--- a/ansible/roles/vault_secrets_operator/meta/main.yml
+++ b/ansible/roles/vault_secrets_operator/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   license: MIT
   min_ansible_version: "2.12"
   platforms:
-    - name: Generic
+    - name: GenericLinux
       versions:
         - all
   galaxy_tags: []

--- a/ansible/roles/velero/tasks/main.yml
+++ b/ansible/roles/velero/tasks/main.yml
@@ -25,7 +25,9 @@
 
 - name: Get Minio credentials from vault
   ansible.builtin.set_fact:
-    velero_minio_credentials: "{{ lookup('community.hashi_vault.vault_kv2_get', velero_minio_vault_path, engine_mount_point='secret') }}"
+    velero_minio_credentials: >-
+      {{ lookup('community.hashi_vault.vault_kv2_get',
+      velero_minio_vault_path, engine_mount_point='secret') }}
   no_log: true
 
 - name: Create Velero secret

--- a/ansible_collections/synology/nas/meta/runtime.yml
+++ b/ansible_collections/synology/nas/meta/runtime.yml
@@ -1,6 +1,2 @@
 # meta/runtime.yml
-requires_ansible: '>=2.10'
-plugin_routing:
-  modules:
-    synology:
-      redirect: synology.nas.synology
+requires_ansible: '>=2.15.0'

--- a/scripts/applications.yml
+++ b/scripts/applications.yml
@@ -1,5 +1,6 @@
 # This playbook will deploy user-facing applications.
-- hosts: localhost
+- name: Deploy user-facing applications
+  hosts: localhost
   roles:
     - rreading_glasses
     - ollama

--- a/scripts/cluster-setup.yml
+++ b/scripts/cluster-setup.yml
@@ -7,5 +7,5 @@
   hosts: localhost
   connection: local
   roles:
-    - role: vault-pki
-    - role: vault-secrets-operator
+    - role: vault_pki
+    - role: vault_secrets_operator

--- a/scripts/core-services.yml
+++ b/scripts/core-services.yml
@@ -1,9 +1,9 @@
 - name: Setup Core Services
   hosts: k3s_masters
   roles:
-    - role: homelab
+    - role: homelab_config
     - vault
-    - vault-secrets-operator
+    - vault_secrets_operator
     - openldap
     - role: efk_stack
     - role: velero


### PR DESCRIPTION
This change addresses a wide range of ansible-lint errors that were causing the CI/CD pipeline to fail.

The following changes were made:
- Added a global `ansible.cfg` file and removed a local one to ensure consistent configuration for ansible and ansible-lint.
- Fixed dozens of YAML syntax and style issues, such as line length, truthy values (yes/no -> true/false), and use of FQCN for modules.
- Corrected variable names to follow the `rolename_varname` convention.
- Updated role metadata to conform to the latest schema requirements.
- Refactored playbooks to correctly import other playbooks and roles.
- Replaced the use of the missing `community.general.nvram` module with `ansible.builtin.raw` to maintain functionality.
- Added the `pfsensible.core` collection to `requirements.yml` to provide the `pfsense` module.
- Removed temporary files created during the development process.