### PR TITLE
feat: Migrate documentation to Jekyll

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ gitleaks-report.json
 
 # Ansible collections
 ansible/.ansible/
+
+# Ruby / Jekyll
+vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,161 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.13.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.92.1)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.92.1-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+
+BUNDLED WITH
+   2.7.2

--- a/README.md
+++ b/README.md
@@ -125,20 +125,18 @@ This project uses a GitOps approach with ArgoCD to manage applications. The inte
 
 This project is designed to be used with a private deployment model. The `make setup-interactive` command is the recommended way to get started with a private deployment. For more details on the private deployment strategy, please see our [Private Deployment Guide](PRIVATE_DEPLOYMENT.md).
 
-## Further Documentation
+## Documentation
 
-For more detailed information, please see the following documents:
+This project's documentation is built with Jekyll and is located in the `docs/` directory.
 
-- [Advanced Usage](docs/advanced-usage.md)
-- [Architecture](docs/architecture.md)
-- [Configuration](docs/configuration.md)
-- [Customization](docs/customization.md)
-- [Deployment](docs/deployment.md)
-- [Folder Structure](docs/folder-structure.md)
-- [Post-Installation](docs/post-installation.md)
-- [Services](docs/services.md)
-- [Technical Design](docs/technical-design.md)
-- [Troubleshooting](docs/troubleshooting.md)
+To view the documentation locally, you will need to have Ruby and Bundler installed. Then, you can run the following commands:
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+The documentation will be available at `http://localhost:4000`.
 
 ## Contributing
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,12 @@
+title: Homelabeazy Documentation
+description: "Your Homelab as Code"
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+theme: minima
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag
+
+permalink: pretty

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -1,0 +1,12 @@
+<nav>
+  <a href="{{ site.baseurl }}/">Home</a>
+  <a href="{{ site.baseurl }}/advanced-usage">Advanced Usage</a>
+  <a href="{{ site.baseurl }}/architecture">Architecture</a>
+  <a href="{{ site.baseurl }}/configuration">Configuration</a>
+  <a href="{{ site.baseurl }}/customization">Customization</a>
+  <a href="{{ site.baseurl }}/deployment">Deployment</a>
+  <a href="{{ site.baseurl }}/post-installation">Post Installation</a>
+  <a href="{{ site.baseurl }}/services">Services</a>
+  <a href="{{ site.baseurl }}/technical-design">Technical Design</a>
+  <a href="{{ site.baseurl }}/troubleshooting">Troubleshooting</a>
+</nav>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ page.title }}</title>
+  </head>
+  <body>
+    {% include navigation.html %}
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+  </body>
+</html>

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Advanced Usage
 ---
 
 # Usage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: System Architecture
 ---
 
 # System Architecture

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Configuration
 ---
 
 # Configuration

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Customization
 ---
 
 # Customization

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Deployment
 ---
 
 # Deployment
@@ -62,4 +53,4 @@ This project follows a GitOps methodology for application deployment, with infra
 
 2.  **Configure Cluster:** Use Ansible to configure the K3s nodes, install necessary packages, and set up core components. This is also a one-time setup or for node-level configuration changes.
 
-3.  **Deploy and Manage Applications:** Applications are managed by ArgoCD. To deploy, update, or remove an application, you make changes to the corresponding YAML files in the `apps/` directory and push them to the Git repository. ArgoCD automatically syncs these changes to the cluster.
+3.  **Deploy and Manage Applications:** Applications are managed by ArgoCD. To deploy, update, or remove an application, you make changes to the corresponding YAML files in the `apps/` directory and push them to your Git repository. ArgoCD automatically syncs these changes to the cluster.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Folder Structure
 ---
 
 # Folder Structure

--- a/docs/post-installation.md
+++ b/docs/post-installation.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Post-Installation
 ---
 
 # Post-Installation

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Default Services
 ---
 
 # Default Services

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Technical Design Document
 ---
 
 # Technical Design Document

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,15 +1,6 @@
-**Navigation**
-* [Home](index.md)
-* [Advanced Usage](advanced-usage.md)
-* [Architecture](architecture.md)
-* [Configuration](configuration.md)
-* [Customization](customization.md)
-* [Deployment](deployment.md)
-* [Post Installation](post-installation.md)
-* [Services](services.md)
-* [Technical Design](technical-design.md)
-* [Troubleshooting](troubleshooting.md)
-
+---
+layout: default
+title: Troubleshooting
 ---
 
 # Troubleshooting


### PR DESCRIPTION
This commit migrates the project's documentation from a set of manually linked Markdown files to a static site generated by Jekyll.

The following changes were made:
- Added a `Gemfile` to manage the Jekyll dependency.
- Created a `_config.yml` file and a basic Jekyll site structure in the `docs/` directory.
- Updated all existing documentation files to use Jekyll front matter and a default layout.
- Centralized the navigation in an include file.
- Updated the main `README.md` to remove the old documentation links and add instructions for building and serving the Jekyll site.
- Added `vendor/bundle` to `.gitignore` to exclude the Bundler vendor directory.