### PR TITLE
fix(ci): grant write permission to deploy docs job

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The GitHub Actions workflow for deploying documentation was failing with a permissions error. This change adds the 'contents: write' permission to the deploy job, allowing it to push the built site to the gh-pages branch.