### PR TITLE
Fix: Remove conflicting homepage role from ansible/requirements.yml

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,7 +6,3 @@ collections:
   - name: pfsensible.core
 
 roles:
-  - name: homepage
-    src: https://github.com/Aidan-Wallace/homepage-kubernetes
-    scm: git
-    version: main


### PR DESCRIPTION
The 'homepage' role was defined in 'ansible/requirements.yml' to be installed from a git repository. This was causing an error during 'ansible-galaxy install' because the specified repository is not a valid Ansible role structure and is missing the 'meta/main.yml' file.

A local, valid 'homepage' role already exists in 'ansible/roles/homepage'. By removing the conflicting entry from 'ansible/requirements.yml', Ansible will use the local role, resolving the installation error.