### PR TITLE
Fix ansible-lint errors

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,3 +6,7 @@ collections:
   - name: pfsensible.core
 
 roles:
+  - src: https://github.com/Aidan-Wallace/homepage-kubernetes.git
+    scm: git
+    version: main
+    name: homepage

--- a/ansible/roles/requirements.yml
+++ b/ansible/roles/requirements.yml
@@ -1,4 +1,0 @@
-- src: https://github.com/Aidan-Wallace/homepage-kubernetes.git
-  scm: git
-  version: main
-  name: homepage

--- a/ansible/roles/vault_pki/tasks/main.yml
+++ b/ansible/roles/vault_pki/tasks/main.yml
@@ -2,6 +2,7 @@
   trippsc2.hashi_vault.vault_pki_secret_engine:
     state: present
     name: pki
+    engine_mount_point: pki
     description: "PKI engine for Traefik"
     default_lease_ttl: "8760h"
     max_lease_ttl: "87600h"


### PR DESCRIPTION
This commit fixes two `ansible-lint` errors that were causing the linting process to fail.

The first error was a schema validation error in `ansible/requirements.yml`. The `roles` key was present but empty, which is not valid. The role definition was incorrectly placed in `ansible/roles/requirements.yml`. This commit moves the role definition to `ansible/requirements.yml` and removes the redundant file.

The second error was a missing `engine_mount_point` argument in the `Enable PKI secrets engine` task in `ansible/roles/vault_pki/tasks/main.yml`. This commit adds the missing argument, resolving the warning from the linter.