### PR TITLE
Fix(ansible): Remove invalid homepage role from requirements

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,7 +6,3 @@ collections:
   - name: pfsensible.core
 
 roles:
-  - src: https://github.com/Aidan-Wallace/homepage-kubernetes.git
-    scm: git
-    version: main
-    name: homepage


### PR DESCRIPTION
The `ansible-galaxy install` command was failing because the `homepage` role in `ansible/requirements.yml` was pointing to a Helm chart repository, not a valid Ansible role.

This change removes the invalid role from the requirements file. The `homepage` application is already being deployed by a local Ansible role that uses the `kubernetes.core.helm` module, so this removal is safe.