### PR TITLE
Fix ansible-lint errors

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,5 +4,3 @@ collections:
   - name: trippsc2.hashi_vault
   - name: community.general
   - name: pfsensible.core
-
-roles:

--- a/ansible/roles/vault_pki/tasks/main.yml
+++ b/ansible/roles/vault_pki/tasks/main.yml
@@ -1,7 +1,6 @@
 - name: Enable PKI secrets engine
   trippsc2.hashi_vault.vault_pki_secret_engine:
     state: present
-    name: pki
     engine_mount_point: pki
     description: "PKI engine for Traefik"
     default_lease_ttl: "8760h"


### PR DESCRIPTION
- Removes the empty `roles` key from `ansible/requirements.yml` to fix a schema validation error.
- Removes the unsupported `name` parameter from the `Enable PKI secrets engine` task in `ansible/roles/vault_pki/tasks/main.yml`.