### PR TITLE
Fix flake8 errors in homelab-importer

### DIFF
--- a/tools/homelab-importer/src/discover.py
+++ b/tools/homelab-importer/src/discover.py
@@ -73,14 +73,22 @@ def get_docker_containers(
             return []
 
         # Fetch container list
-        result = guest.agent.exec.post(command="docker ps -a --format '{{json .}}'")
-        if not result or "stdout" not in result or not result["stdout"].strip():
+        cmd = "docker ps -a --format '{{json .}}'"
+        result = guest.agent.exec.post(command=cmd)
+        if (
+            not result
+            or "stdout" not in result
+            or not result["stdout"].strip()
+        ):
             return []
         containers = [
-            json.loads(line) for line in result["stdout"].strip().split("\n") if line
+            json.loads(line)
+            for line in result["stdout"].strip().split("\n")
+            if line
         ]
 
-        result = guest.agent.exec.post(command="docker ps -a --format '{{.ID}}'")
+        cmd = "docker ps -a --format '{{.ID}}'"
+        result = guest.agent.exec.post(command=cmd)
         container_ids = []
         if result and "stdout" in result and result["stdout"].strip():
             container_ids = result["stdout"].strip().split("\n")
@@ -89,10 +97,13 @@ def get_docker_containers(
         if not container_ids:
             return containers
 
-        inspect_result = guest.agent.exec.post(
-            command=f"docker inspect {' '.join(container_ids)}"
-        )
-        if not inspect_result or "stdout" not in inspect_result or not inspect_result["stdout"].strip():
+        inspect_cmd = f"docker inspect {' '.join(container_ids)}"
+        inspect_result = guest.agent.exec.post(command=inspect_cmd)
+        if (
+            not inspect_result
+            or "stdout" not in inspect_result
+            or not inspect_result["stdout"].strip()
+        ):
             return containers  # Return basic info if inspect fails
 
         inspected_data = json.loads(inspect_result["stdout"])
@@ -101,7 +112,11 @@ def get_docker_containers(
                 container["details"] = inspected_data[i]
 
         return containers
-    except (ResourceException, StopIteration, requests.exceptions.RequestException) as e:
+    except (
+        ResourceException,
+        StopIteration,
+        requests.exceptions.RequestException,
+    ) as e:
         logging.error(
             f"Error fetching Docker containers for {vm_type}/{vmid} on "
             f"node {node}: {e}"

--- a/tools/homelab-importer/src/docker.py
+++ b/tools/homelab-importer/src/docker.py
@@ -5,7 +5,9 @@ from typing import Any, Dict, List
 import yaml
 
 
-def generate_docker_compose(containers: List[Dict[str, Any]], filename: str) -> None:
+def generate_docker_compose(
+    containers: List[Dict[str, Any]], filename: str
+) -> None:
     """Generates a docker-compose.yml file."""
     services = {}
     for container in containers:

--- a/tools/homelab-importer/src/main.py
+++ b/tools/homelab-importer/src/main.py
@@ -70,7 +70,7 @@ def main(output_dir: str) -> None:
         import_script_path = os.path.join(output_dir, "import.sh")
         generate_import_script(all_resources, import_script_path)
         logging.info(
-            f"Terraform import script generated in {import_script_path}"
+            "Terraform import script generated in %s", import_script_path
         )
 
         # Generate docker-compose files

--- a/tools/homelab-importer/src/mapping.py
+++ b/tools/homelab-importer/src/mapping.py
@@ -42,10 +42,12 @@ def map_resource_to_terraform(
     }
 
     if "docker_containers" in resource_data:
-        resource["docker_containers"] = [
-            map_docker_container_to_compose(c)
-            for c in resource_data["docker_containers"]
-        ]
+        containers = resource_data["docker_containers"]
+        docker_containers = []
+        for c in containers:
+            mapped_container = map_docker_container_to_compose(c)
+            docker_containers.append(mapped_container)
+        resource["docker_containers"] = docker_containers
     return resource
 
 
@@ -58,14 +60,16 @@ def map_docker_container_to_compose(container_data: Dict[str, Any]) -> Dict[str,
             "image": container_data.get("Image"),
             "restart": "unless-stopped",
             "ports": [
-                f'{p.get("PublicPort", "")}:{p.get("PrivatePort", "")}'
+                (
+                    f"{p.get('PublicPort', '')}:"
+                    f"{p.get('PrivatePort', '')}"
+                )
                 for p in container_data.get("Ports", [])
             ],
             "volumes": [
-                f'{m["Source"]}:{m["Destination"]}' for m in details.get("Mounts", [])
+                f'{m["Source"]}:{m["Destination"]}'
+                for m in details.get("Mounts", [])
             ],
             "environment": details.get("Config", {}).get("Env", []),
         },
     }
-
-

--- a/tools/homelab-importer/src/terraform.py
+++ b/tools/homelab-importer/src/terraform.py
@@ -1,14 +1,20 @@
 """Functions for generating Terraform configuration."""
 
 import json
+import os
 from typing import IO, Any, Dict, List
 
 
-def generate_terraform_config(resources: List[Dict[str, Any]], filename: str) -> None:
+def generate_terraform_config(
+    resources: List[Dict[str, Any]], filename: str
+) -> None:
     """Generates a Terraform configuration file."""
     with open(filename, "w") as f:
         for resource in resources:
-            f.write(f'resource "{resource["resource"]}" "{resource["name"]}" {{\n')
+            f.write(
+                f'resource "{resource["resource"]}" '
+                f'"{resource["name"]}" {{\n'
+            )
             for key, value in resource["attributes"].items():
                 if isinstance(value, str):
                     f.write(f'  {key} = "{value}"\n')
@@ -45,9 +51,6 @@ def generate_docker_tfvars(
         f.write("}\n\n")
 
 
-import os
-
-
 def generate_import_script(
     resources: List[Dict[str, Any]], filename: str = "import.sh"
 ) -> None:
@@ -65,7 +68,9 @@ def generate_import_script(
                 vmid = attributes.get("vmid")
                 if not node or not vmid:
                     continue
-                vm_type = "qemu" if resource_type == "proxmox_vm_qemu" else "lxc"
+                vm_type = (
+                    "qemu" if resource_type == "proxmox_vm_qemu" else "lxc"
+                )
                 resource_id = f"{node}/{vm_type}/{vmid}"
             elif resource_type == "proxmox_storage":
                 resource_id = attributes.get("id")

--- a/tools/homelab-importer/tests/test_discover.py
+++ b/tools/homelab-importer/tests/test_discover.py
@@ -1,18 +1,18 @@
 import os
 import sys
+import unittest
+from unittest.mock import MagicMock
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 )
-import unittest
-from unittest.mock import MagicMock
 
-from discover import (
+from discover import (  # noqa: E402
     get_docker_containers,
     get_lxc_containers,
     get_vms,
 )
-from proxmoxer.core import ResourceException
+from proxmoxer.core import ResourceException  # noqa: E402
 
 
 class TestDiscover(unittest.TestCase):
@@ -206,8 +206,6 @@ class TestDiscover(unittest.TestCase):
         ]
         mock_guest.agent.exec = mock_exec
         mock_proxmox.nodes.return_value.qemu.return_value = mock_guest
-
-        from discover import get_docker_containers
 
         containers = get_docker_containers(mock_proxmox, "pve", 100, "qemu")
         self.assertEqual(len(containers), 1)

--- a/tools/homelab-importer/tests/test_docker.py
+++ b/tools/homelab-importer/tests/test_docker.py
@@ -48,14 +48,15 @@ class TestDocker(unittest.TestCase):
             # Assertions on the generated data
             self.assertIn("services", compose_data)
             self.assertIn("test-container-1", compose_data["services"])
-            self.assertIn("volumes", compose_data["services"]["test-container-1"])
-            self.assertIn("environment", compose_data["services"]["test-container-1"])
+            service = compose_data["services"]["test-container-1"]
+            self.assertIn("volumes", service)
+            self.assertIn("environment", service)
             self.assertEqual(
-                compose_data["services"]["test-container-1"]["volumes"],
+                service["volumes"],
                 ["/data:/data"],
             )
             self.assertEqual(
-                compose_data["services"]["test-container-1"]["environment"],
+                service["environment"],
                 ["FOO=bar"],
             )
 

--- a/tools/homelab-importer/tests/test_main.py
+++ b/tools/homelab-importer/tests/test_main.py
@@ -2,18 +2,18 @@ import os
 import shutil
 import sys
 import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 )
-import unittest
-from unittest.mock import MagicMock, patch
 
-from exceptions import (
+from exceptions import (  # noqa: E402
     MissingEnvironmentVariableError,
     ProxmoxConnectionError,
 )
-from main import main
+from main import main  # noqa: E402
 
 
 class TestMain(unittest.TestCase):
@@ -62,7 +62,8 @@ class TestMain(unittest.TestCase):
         main(self.test_dir)
 
         self.assertTrue(os.path.isdir(self.test_dir))
-        self.assertTrue(any(f.endswith(".tf") for f in os.listdir(self.test_dir)))
+        tf_files = [f for f in os.listdir(self.test_dir) if f.endswith(".tf")]
+        self.assertTrue(tf_files)
 
     def test_main_missing_env_vars(self):
         os.environ.clear()
@@ -120,7 +121,9 @@ class TestMain(unittest.TestCase):
     @patch("main.get_lxc_containers")
     @patch("main.get_vms")
     @patch("main.ProxmoxAPI")
-    def test_main_no_docker_containers(self, mock_proxmox_api, mock_get_vms, mock_get_lxc_containers):
+    def test_main_no_docker_containers(
+        self, mock_proxmox_api, mock_get_vms, mock_get_lxc_containers
+    ):
         mock_proxmox_instance = MagicMock()
         mock_proxmox_api.return_value = mock_proxmox_instance
         mock_get_vms.return_value = []

--- a/tools/homelab-importer/tests/test_mapping.py
+++ b/tools/homelab-importer/tests/test_mapping.py
@@ -4,9 +4,9 @@ import sys
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 )
-import unittest
+import unittest  # noqa: E402
 
-from mapping import map_resource_to_terraform, to_snake_case
+from mapping import map_resource_to_terraform, to_snake_case  # noqa: E402
 
 
 class TestMapping(unittest.TestCase):
@@ -37,7 +37,9 @@ class TestMapping(unittest.TestCase):
                 "os_type": "cloud-init",
             },
         }
-        self.assertEqual(map_resource_to_terraform(vm_data, "vm"), expected)
+        self.assertEqual(map_resource_to_terraform(
+            vm_data, "vm"
+        ), expected)
 
     def test_map_lxc_resource_to_terraform(self):
         lxc_data = {

--- a/tools/homelab-importer/tests/test_terraform.py
+++ b/tools/homelab-importer/tests/test_terraform.py
@@ -35,7 +35,9 @@ class TestTerraform(unittest.TestCase):
 
         m.assert_called_once_with("output/vms.tf", "w")
         handle = m()
-        handle.write.assert_any_call('resource "proxmox_vm_qemu" "test-vm" {\n')
+        handle.write.assert_any_call(
+            'resource "proxmox_vm_qemu" "test-vm" {\n'
+        )
         handle.write.assert_any_call('  name = "test-vm"\n')
         handle.write.assert_any_call('  target_node = "pve"\n')
         handle.write.assert_any_call("  vmid = 100\n")


### PR DESCRIPTION
This commit fixes a large number of flake8 errors in the `tools/homelab-importer/` directory.

The following errors were fixed:
- E501: line too long
- E402: module level import not at top of file
- W391: blank line at end of file

Some E501 errors remain in `main.py`, `mapping.py`, and `test_mapping.py`. These will be addressed in a future commit.