### PR TITLE
Fix: Repair Jekyll build in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,10 +25,7 @@ jobs:
           bundle install --gemfile=docs/Gemfile --jobs 4 --retry 3
 
       - name: Build and Deploy
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./docs
-          destination: ./_site
+        run: bundle exec jekyll build --source ./docs --destination ./_site
         env:
           JEKYLL_ENV: production
           BASE_URL: /homelabeazy


### PR DESCRIPTION
The Jekyll documentation build was failing in the GitHub Actions workflow. The `actions/jekyll-build-pages@v1` action does not use the gems installed by `bundle install`, which caused a `Gem::MissingSpecError` because the `jekyll-theme-chirpy` theme was not found in the action's default environment.

This change replaces the `actions/jekyll-build-pages@v1` action with a manual build step: `bundle exec jekyll build`. This ensures that the build process uses the gems specified in `docs/Gemfile` and installed in the previous workflow step, resolving the dependency issue.