### PR TITLE
The Jekyll documentation build was failing in the `deploy-docs` workf…

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           JEKYLL_ENV: production
           BASE_URL: /homelabeazy
+          BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
…low.

The error "Could not find jekyll-4.4.1" indicated that bundler was not using the correct Gemfile.

The workflow was running `bundle install` with `--gemfile=docs/Gemfile`, but the `bundle exec` command was implicitly using the `Gemfile` from the repository root.

This change fixes the build by explicitly setting the `BUNDLE_GEMFILE` environment variable to point to `docs/Gemfile` for the `bundle exec` command. This ensures that the correct set of gems is used for building the documentation site.