### PR TITLE
feat: Add documentation sidebar

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,0 +1,134 @@
+<!-- The Side Bar -->
+
+<aside aria-label="Sidebar" id="sidebar" class="d-flex flex-column align-items-end">
+  <header class="profile-wrapper">
+    <a href="{{ '/' | relative_url }}" id="avatar" class="rounded-circle">
+      {%- if site.avatar != empty and site.avatar -%}
+        {%- capture avatar_url -%}
+          {% include media-url.html src=site.avatar %}
+        {%- endcapture -%}
+        <img src="{{- avatar_url -}}" width="112" height="112" alt="avatar" onerror="this.style.display='none'">
+      {%- endif -%}
+    </a>
+
+    <a class="site-title d-block" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+    <p class="site-subtitle fst-italic mb-0">{{ site.tagline }}</p>
+  </header>
+  <!-- .profile-wrapper -->
+
+  <nav class="flex-column flex-grow-1 w-100 ps-0">
+    <ul class="nav">
+      <!-- home -->
+      <li class="nav-item{% if page.layout == 'home' %}{{ " active" }}{% endif %}">
+        <a href="{{ '/' | relative_url }}" class="nav-link">
+          <i class="fa-fw fas fa-home"></i>
+          <span>{{ site.data.locales[include.lang].tabs.home | upcase }}</span>
+        </a>
+      </li>
+      <!-- the real tabs -->
+      {% for tab in site.tabs %}
+        <li class="nav-item{% if tab.url == page.url %}{{ " active" }}{% endif %}">
+          <a href="{{ tab.url | relative_url }}" class="nav-link">
+            <i class="fa-fw {{ tab.icon }}"></i>
+            {% capture tab_name %}{{ tab.url | split: '/' }}{% endcapture %}
+
+            <span>{{ site.data.locales[include.lang].tabs.[tab_name] | default: tab.title | upcase }}</span>
+          </a>
+        </li>
+        <!-- .nav-item -->
+      {% endfor %}
+
+      <!--
+        documentation pages
+      -->
+      <li class="nav-item">
+        <a
+          class="nav-link d-flex justify-content-between"
+          href="#documentation-list"
+          data-bs-toggle="collapse"
+          aria-expanded="false"
+          aria-controls="documentation-list"
+        >
+          <span>
+            <i class="fa-fw fas fa-book"></i>
+            <span>DOCUMENTATION</span>
+          </span>
+          <i class="fas fa-angle-down"></i>
+        </a>
+        <ul id="documentation-list" class="collapse">
+          {% assign docs = site.pages | where: "category", "documentation" | sort: "nav_order" %}
+          {% for doc in docs %}
+          <li class="nav-item">
+            <a href="{{ doc.url | relative_url }}" class="nav-link">
+              <span>{{ doc.title }}</span>
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="sidebar-bottom d-flex flex-wrap  align-items-center w-100">
+    {% unless site.theme_mode %}
+      <button type="button" class="btn btn-link nav-link" aria-label="Switch Mode" id="mode-toggle">
+        <i class="fas fa-adjust"></i>
+      </button>
+
+      {% if site.data.contact.size > 0 %}
+        <span class="icon-border"></span>
+      {% endif %}
+    {% endunless %}
+
+    {% for entry in site.data.contact %}
+      {%- assign url = null -%}
+
+      {% case entry.type %}
+        {% when 'github', 'twitter' %}
+          {%- unless site[entry.type].username -%}
+            {%- continue -%}
+          {%- endunless -%}
+          {%- capture url -%}
+            https://{{ entry.type }}.com/{{ site[entry.type].username }}
+          {%- endcapture -%}
+        {% when 'email' %}
+          {%- unless site.social.email -%}
+            {%- continue -%}
+          {%- endunless -%}
+          {%- assign email = site.social.email | split: '@' -%}
+          {%- capture url -%}
+            javascript:location.href = 'mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@')
+          {%- endcapture -%}
+        {% when 'rss' %}
+          {% assign url = '/feed.xml' | relative_url %}
+        {% else %}
+          {% assign url = entry.url %}
+      {% endcase %}
+
+      {% if url %}
+        <a
+          href="{{ url }}"
+          aria-label="{{ entry.type }}"
+          {% assign link_types = '' %}
+
+          {% unless entry.noblank %}
+            target="_blank"
+            {% assign link_types = 'noopener noreferrer' %}
+          {% endunless %}
+
+          {% if entry.type == 'mastodon' %}
+            {% assign link_types = link_types | append: ' me' | strip %}
+          {% endif %}
+
+          {% unless link_types == empty %}
+            rel="{{ link_types }}"
+          {% endunless %}
+        >
+          <i class="{{ entry.icon }}"></i>
+        </a>
+      {% endif %}
+    {% endfor %}
+  </div>
+  <!-- .sidebar-bottom -->
+</aside>
+<!-- #sidebar -->

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,13 +1,86 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ page.title }}</title>
-  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
-</head><body>
-  <div class="container">
-    {{ content }}
-  </div>
-</body>
+---
+layout: compress
+---
+
+<!doctype html>
+
+{% include origin-type.html %}
+
+{% include lang.html %}
+
+{% if site.theme_mode %}
+  {% capture prefer_mode %}data-mode="{{ site.theme_mode }}"{% endcapture %}
+{% endif %}
+
+<!-- `site.alt_lang` can specify a language different from the UI -->
+<html lang="{{ page.lang | default: site.alt_lang | default: site.lang }}" {{ prefer_mode }}>
+  {% include head.html %}
+
+  <body>
+    {% include sidebar.html lang=lang %}
+
+    <div id="main-wrapper" class="d-flex justify-content-center">
+      <div class="container d-flex flex-column px-xxl-5">
+        {% include topbar.html lang=lang %}
+
+        <div class="row flex-grow-1">
+          <main aria-label="Main Content" class="col-12 col-lg-11 col-xl-9 px-md-4">
+            {% if layout.refactor or layout.layout == 'default' %}
+              {% include refactor-content.html content=content lang=lang %}
+            {% else %}
+              {{ content }}
+            {% endif %}
+          </main>
+
+          <!-- panel -->
+          <aside aria-label="Panel" id="panel-wrapper" class="col-xl-3 ps-2 text-muted">
+            <div class="access">
+              {% include_cached update-list.html lang=lang %}
+              {% include_cached trending-tags.html lang=lang %}
+            </div>
+
+            {% for _include in layout.panel_includes %}
+              {% assign _include_path = _include | append: '.html' %}
+              {% include {{ _include_path }} lang=lang %}
+            {% endfor %}
+          </aside>
+        </div>
+
+        <div class="row">
+          <!-- tail -->
+          <div id="tail-wrapper" class="col-12 col-lg-11 col-xl-9 px-md-4">
+            {% for _include in layout.tail_includes %}
+              {% assign _include_path = _include | append: '.html' %}
+              {% include {{ _include_path }} lang=lang %}
+            {% endfor %}
+
+            {% include_cached footer.html lang=lang %}
+          </div>
+        </div>
+
+        {% include_cached search-results.html lang=lang %}
+      </div>
+
+      <aside aria-label="Scroll to Top">
+        <button id="back-to-top" type="button" class="btn btn-lg btn-box-shadow">
+          <i class="fas fa-angle-up"></i>
+        </button>
+      </aside>
+    </div>
+
+    <div id="mask" class="d-none position-fixed w-100 h-100 z-1"></div>
+
+    {% if site.pwa.enabled %}
+      {% include_cached notification.html lang=lang %}
+    {% endif %}
+
+    <!-- Embedded scripts -->
+
+    {% for _include in layout.script_includes %}
+      {% assign _include_path = _include | append: '.html' %}
+      {% include {{ _include_path }} %}
+    {% endfor %}
+
+    {% include_cached search-loader.html lang=lang %}
+  </body>
 </html>

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -2,6 +2,7 @@
 layout: default
 title: Advanced Usage
 nav_order: 8
+category: documentation
 ---
 
 # Usage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,7 @@
 layout: default
 title: System Architecture
 nav_order: 4
+category: documentation
 ---
 
 # System Architecture

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,7 @@
 layout: default
 title: Configuration
 nav_order: 2
+category: documentation
 ---
 
 # Configuration

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -2,6 +2,7 @@
 layout: default
 title: Customization
 nav_order: 7
+category: documentation
 ---
 
 # Customization

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,7 @@
 layout: default
 title: Deployment
 nav_order: 5
+category: documentation
 ---
 
 # Deployment

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -2,6 +2,7 @@
 layout: default
 title: Folder Structure
 nav_order: 3
+category: documentation
 ---
 
 # Folder Structure

--- a/docs/post-installation.md
+++ b/docs/post-installation.md
@@ -2,6 +2,7 @@
 layout: default
 title: Post-Installation
 nav_order: 6
+category: documentation
 ---
 
 # Post-Installation

--- a/docs/services.md
+++ b/docs/services.md
@@ -2,6 +2,7 @@
 layout: default
 title: Default Services
 nav_order: 9
+category: documentation
 ---
 
 # Default Services

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -2,6 +2,7 @@
 layout: default
 title: Technical Design Document
 nav_order: 10
+category: documentation
 ---
 
 # Technical Design Document

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,7 @@
 layout: default
 title: Troubleshooting
 nav_order: 11
+category: documentation
 ---
 
 # Troubleshooting


### PR DESCRIPTION
This change adds a custom sidebar to the documentation site to display all the documentation pages.

- Adds `category: documentation` to the front matter of all documentation pages.
- Creates a custom `_includes/sidebar.html` to override the theme's sidebar.
- The custom sidebar now includes a collapsible section that lists all pages with the `documentation` category, sorted by the `nav_order` front matter.