### PR TITLE
fix(ci): correct htmlproofer ignore flag

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           bundle exec htmlproofer ./_site \
             --disable-external \
-            --ignore-urls "/.*/"
+            --url-ignore "/.*/"
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
 


### PR DESCRIPTION
The --ignore-urls flag is not a valid option for htmlproofer. This commit replaces it with the correct --url-ignore flag to fix the failing documentation deployment workflow.