### PR TITLE
feat(docs): Create missing origin-type.html

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 docs/_site
+vendor/


### PR DESCRIPTION
The Jekyll build was failing with an error indicating that the `origin-type.html` file could not be found in the `_includes` directory. This change creates an empty file at that location to resolve the error.

Additionally, this change updates the `docs/.gitignore` to exclude the `vendor/` directory, which is a common practice for vendored dependencies.