### PR TITLE
Fix Jekyll build error in docs site

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -6,8 +6,6 @@ layout: compress
 
 {% include origin-type.html %}
 
-{% include lang.html %}
-
 {% if site.theme_mode %}
   {% capture prefer_mode %}data-mode="{{ site.theme_mode }}"{% endcapture %}
 {% endif %}


### PR DESCRIPTION
The Jekyll build was failing with a "Liquid Exception: Could not locate the included file 'lang.html'". This was caused by the `docs/_layouts/default.html` file trying to include `lang.html`, which does not exist in the `minimal-mistakes-jekyll` theme or in the local `_includes` directory.

This change removes the include statement for `lang.html`, which resolves the build error.