### PR TITLE
feat: Apply neon skin to Jekyll site and update README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**For full documentation, visit our [GitHub Pages site](https://toxicoder.github.io/homelabeazy).**
+**For full documentation, visit our <a href="https://toxicoder.github.io/homelabeazy" target="_blank">GitHub Pages site</a>.**
 
 # Homelabeazy - Your _Homelab as Code_
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,9 @@
 # Import the theme
 theme: minimal-mistakes-jekyll
 
+# Minimal Mistakes skin
+skin: "neon"
+
 # The language of the webpage › http://www.lingoes.net/en/translator/langcode.htm
 # If it has the same name as one of the files in folder `_data/locales`, the layout language will also be changed,
 # otherwise, the layout language will use the default value of 'en'.


### PR DESCRIPTION
This commit applies the "neon" skin to the Jekyll site by adding the `skin: "neon"` setting to the `docs/_config.yml` file.

Additionally, it updates the hyperlink in the main README.md file to open the documentation in a new tab.