### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -25,7 +25,7 @@ The `Makefile` at the root of the project provides a number of helpful commands 
 
 If you have an existing homelab that was configured manually, you can use the `homelab-importer` tool to import it into a Terraform-managed setup. This is a great way to migrate your existing homelab to the Infrastructure as Code (IaC) approach used by this project.
 
-For detailed instructions on how to use the importer, please see the [Homelab Importer README](tools/homelab-importer/README.md).
+For detailed instructions on how to use the importer, please see the [Homelab Importer README](../tools/homelab-importer/README.md).
 
 ## OpenLDAP
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -18,7 +18,7 @@ The heart of your homelab is the applications you run on it. Homelabeazy uses a 
 4.  **Add the new application to the "app of apps":** Add a new entry for your application in the `apps/app-of-apps.yml` file. This will tell ArgoCD to start managing your new application.
 5.  **Commit and push your changes:** Once you commit and push your changes to your Git repository, ArgoCD will automatically detect the new application and deploy it to your cluster.
 
-For a more detailed walkthrough of this process, please see the [Adding New Applications](./adding-new-applications.md) guide.
+For a more detailed walkthrough of this process, please see the [Adding New Applications](#adding-new-applications) guide.
 
 ## Managing Secrets
 


### PR DESCRIPTION
This commit fixes two broken links in the documentation:

1.  In `docs/advanced-usage.md`, the link to the `homelab-importer` README was incorrect. It has been updated to the correct relative path.

2.  In `docs/customization.md`, the link to the `adding-new-applications.md` file was broken as the file does not exist. The link has been changed to point to the "Adding New Applications" section within the same document. This provides the user with the relevant information that was likely intended by the original link.