### PR TITLE
Fix: Re-order Jekyll navigation

### DIFF
--- a/docs/_tabs/advanced-usage.md
+++ b/docs/_tabs/advanced-usage.md
@@ -2,7 +2,7 @@
 layout: default
 title: Advanced Usage
 parent: Guides
-nav_order: 6
+nav_order: 2
 permalink: /advanced-usage
 ---
 

--- a/docs/_tabs/community.md
+++ b/docs/_tabs/community.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Community
-nav_order: 11
+nav_order: 3
 permalink: /community
 ---
 

--- a/docs/_tabs/configuration.md
+++ b/docs/_tabs/configuration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Configuration
 parent: Reference
-nav_order: 3
+nav_order: 2
 permalink: /configuration
 has_children: true
 ---

--- a/docs/_tabs/customization.md
+++ b/docs/_tabs/customization.md
@@ -2,7 +2,7 @@
 layout: default
 title: Customization
 parent: Guides
-nav_order: 8
+nav_order: 3
 permalink: /customization
 ---
 

--- a/docs/_tabs/deployment.md
+++ b/docs/_tabs/deployment.md
@@ -2,7 +2,7 @@
 layout: default
 title: Deployment
 parent: Reference
-nav_order: 4
+nav_order: 3
 permalink: /deployment
 ---
 

--- a/docs/_tabs/folder-structure.md
+++ b/docs/_tabs/folder-structure.md
@@ -2,7 +2,7 @@
 layout: default
 title: Folder Structure
 parent: Reference
-nav_order: 7
+nav_order: 5
 permalink: /folder-structure
 ---
 

--- a/docs/_tabs/guides.md
+++ b/docs/_tabs/guides.md
@@ -1,6 +1,6 @@
 ---
 layout: default
 title: Guides
-nav_order: 2
+nav_order: 1
 has_children: true
 ---

--- a/docs/_tabs/reference.md
+++ b/docs/_tabs/reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Reference
-nav_order: 9
+nav_order: 2
 permalink: /reference
 has_children: true
 ---

--- a/docs/_tabs/services.md
+++ b/docs/_tabs/services.md
@@ -2,7 +2,7 @@
 layout: default
 title: Services
 parent: Reference
-nav_order: 5
+nav_order: 4
 permalink: /services
 ---
 

--- a/docs/_tabs/troubleshooting.md
+++ b/docs/_tabs/troubleshooting.md
@@ -2,7 +2,7 @@
 layout: default
 title: Troubleshooting
 parent: Guides
-nav_order: 11
+nav_order: 4
 permalink: /troubleshooting
 ---
 


### PR DESCRIPTION
The navigation for the Jekyll site was not appearing in the correct order due to duplicate and non-sequential `nav_order` values in the front matter of the markdown files.

This commit fixes the issue by re-assigning the `nav_order` values for all navigation items in the `docs/_tabs` directory. The new values are sequential and unique for each level of the navigation hierarchy, ensuring a predictable and logical navigation structure.

The top-level pages and their children have been re-ordered as follows:

- Guides (1)
  - Getting Started (1)
  - Advanced Usage (2)
  - Customization (3)
  - Troubleshooting (4)
- Reference (2)
  - Technical Design (1)
  - Configuration (2)
  - Deployment (3)
  - Services (4)
  - Folder Structure (5)
- Community (3)