### PR TITLE
fix(docs): Resolve broken links in documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,7 +35,7 @@ search_enabled: true
 toc: true
 
 # The base URL of your site
-baseurl: "/homelabeazy"
+baseurl: ""
 
 # ------------ The following options are not recommended to be modified ------------------
 

--- a/docs/_tabs/advanced-usage.md
+++ b/docs/_tabs/advanced-usage.md
@@ -27,7 +27,7 @@ The `Makefile` at the root of the project provides a number of helpful commands 
 
 If you have an existing homelab that was configured manually, you can use the `homelab-importer` tool to import it into a Terraform-managed setup. This is a great way to migrate your existing homelab to the Infrastructure as Code (IaC) approach used by this project.
 
-For detailed instructions on how to use the importer, please see the [Technical Design](./technical-design.md) guide.
+For detailed instructions on how to use the importer, please see the [Technical Design](./technical-design) guide.
 
 ## OpenLDAP
 

--- a/docs/_tabs/deployment.md
+++ b/docs/_tabs/deployment.md
@@ -50,4 +50,4 @@ This will install K3s on the virtual machines and configure them to form a Kuber
 
 Applications are deployed to your cluster using a GitOps workflow with ArgoCD. To deploy a new application, you'll need to create a new YAML file in the `apps/` directory of your private configuration repository.
 
-For more information on how to add new applications, please see the [Customization](./customization.md) guide.
+For more information on how to add new applications, please see the [Customization](./customization) guide.

--- a/docs/_tabs/getting-started.md
+++ b/docs/_tabs/getting-started.md
@@ -122,4 +122,4 @@ You've now successfully set up your homelab and deployed your first application.
 *   **Explore the available applications:** The Homelabeazy project comes with a number of pre-configured applications that you can deploy to your cluster. Check out the `apps/` directory in the repository.
 *   **Add your own applications:** You can easily add your own applications to your homelab by creating new Helm charts or by using existing ones.
 *   **Customize your setup:** The Homelabeazy project is highly customizable. You can change the network configuration, add new services, and integrate with other systems.
-*   **Contribute to the project:** If you've found a bug or have an idea for a new feature, we'd love to hear from you! Check out our [Contributing Guide](./community.md) for more information.
+*   **Contribute to the project:** If you've found a bug or have an idea for a new feature, we'd love to hear from you! Check out our [Contributing Guide](./community) for more information.

--- a/docs/_tabs/technical-design.md
+++ b/docs/_tabs/technical-design.md
@@ -14,7 +14,7 @@ Welcome to the Technical Design Document for Homelabeazy. This document provides
 
 ### Who is this for?
 
-This document is intended for users who have a basic understanding of the core technologies used in this project, such as Proxmox, Terraform, Ansible, and Kubernetes. If you're new to these technologies, we recommend that you start with our [Getting Started guide](./guides.md) and then come back to this document for a deeper dive.
+This document is intended for users who have a basic understanding of the core technologies used in this project, such as Proxmox, Terraform, Ansible, and Kubernetes. If you're new to these technologies, we recommend that you start with our [Getting Started guide](./guides) and then come back to this document for a deeper dive.
 
 ### Design Philosophy
 
@@ -214,7 +214,7 @@ The project uses a VLAN-based network segmentation strategy to isolate traffic a
 
 ## 5. Scalability and Customization
 
-This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide](customization.md).
+This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide](customization).
 
 ---
 

--- a/docs/_tabs/troubleshooting.md
+++ b/docs/_tabs/troubleshooting.md
@@ -84,4 +84,4 @@ If you encounter an issue that you cannot resolve, you can restart the setup pro
     rm infrastructure/proxmox/terraform.tfvars
     rm ansible/inventory/inventory.auto.yml
     ```
-3.  **Run the setup process again by following the steps in the [Getting Started](./getting-started.md) guide.**
+3.  **Run the setup process again by following the steps in the [Getting Started](./getting-started) guide.**


### PR DESCRIPTION
The htmlproofer check was failing due to two issues:
1. The `baseurl` was incorrectly set to `/homelabeazy` in `docs/_config.yml`, causing broken asset and page links.
2. Internal links to other documentation pages were using the `.md` extension, which is incorrect for the generated site.

This commit addresses these issues by:
- Setting the `baseurl` to `""` in `docs/_config.yml`.
- Removing the `.md` extension from all internal links in the `docs/_tabs` directory.