### PR TITLE
Fix broken links in documentation site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -67,7 +67,6 @@ compress_html:
 exclude:
   - "*.gem"
   - "*.gemspec"
-  - docs
   - tools
   - README.md
   - LICENSE

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,13 +9,13 @@ Homelabeazy is a project that aims to make it easy to set up and manage your own
 
 ## Getting Started
 
-If you are new to Homelabeazy, we recommend starting with the [Getting Started](docs/guides/getting-started.html) guide. This guide will walk you through the process of setting up your homelab from scratch.
+If you are new to Homelabeazy, we recommend starting with the [Getting Started]({% link docs/guides/getting-started.md %}) guide. This guide will walk you through the process of setting up your homelab from scratch.
 
 ## Documentation
 
 The documentation is divided into the following sections:
 
-- **[Guides](docs/guides/):** Step-by-step guides to help you set up and configure your homelab.
-- **[Reference](docs/reference/):** Detailed information about the various components of Homelabeazy.
-- **[Community](community.html):** Information about how to get involved in the Homelabeazy community.
-- **[Troubleshooting](docs/guides/troubleshooting.html):** Solutions to common problems you may encounter.
+- **[Guides]({% link docs/guides/index.md %}):** Step-by-step guides to help you set up and configure your homelab.
+- **[Reference]({% link docs/reference/index.md %}):** Detailed information about the various components of Homelabeazy.
+- **[Community]({% link docs/community.md %}):** Information about how to get involved in the Homelabeazy community.
+- **[Troubleshooting]({% link docs/guides/troubleshooting.md %}):** Solutions to common problems you may encounter.


### PR DESCRIPTION
The htmlproofer check was failing due to multiple broken internal links on the main documentation page.

This was caused by two issues:
1. The `docs` directory was being excluded from the Jekyll build in `docs/_config.yml`, which meant none of the documentation pages were being generated.
2. The links in `docs/index.md` were hardcoded and some were incorrect.

This commit resolves the issues by:
- Removing `docs` from the `exclude` list in `docs/_config.yml`.
- Replacing all hardcoded documentation links in `docs/index.md` with Jekyll's `{% link %}` tag. This makes the links more robust and ensures they are validated at build time.