### PR TITLE
Fix broken internal links in the documentation.

### DIFF
--- a/docs/docs/guides/advanced-usage.md
+++ b/docs/docs/guides/advanced-usage.md
@@ -24,7 +24,7 @@ The `Makefile` at the root of the project provides a number of helpful commands 
 
 If you have an existing homelab that was configured manually, you can use the `homelab-importer` tool to import it into a Terraform-managed setup. This is a great way to migrate your existing homelab to the Infrastructure as Code (IaC) approach used by this project.
 
-For detailed instructions on how to use the importer, please see the [Technical Design](./technical-design) guide.
+For detailed instructions on how to use the importer, please see the [Technical Design](../reference/technical-design.md) guide.
 
 ## OpenLDAP
 

--- a/docs/docs/reference/technical-design.md
+++ b/docs/docs/reference/technical-design.md
@@ -11,7 +11,7 @@ Welcome to the Technical Design Document for Homelabeazy. This document provides
 
 ### Who is this for?
 
-This document is intended for users who have a basic understanding of the core technologies used in this project, such as Proxmox, Terraform, Ansible, and Kubernetes. If you're new to these technologies, we recommend that you start with our [Getting Started guide](./guides) and then come back to this document for a deeper dive.
+This document is intended for users who have a basic understanding of the core technologies used in this project, such as Proxmox, Terraform, Ansible, and Kubernetes. If you're new to these technologies, we recommend that you start with our [Getting Started guide](../guides/) and then come back to this document for a deeper dive.
 
 ### Design Philosophy
 
@@ -211,7 +211,7 @@ The project uses a VLAN-based network segmentation strategy to isolate traffic a
 
 ## 5. Scalability and Customization
 
-This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide](customization).
+This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide](../guides/customization.md).
 
 ---
 


### PR DESCRIPTION
The htmlproofer check was failing due to three broken links in the documentation. This commit fixes the incorrect relative paths in the following files:
- docs/docs/guides/advanced-usage.md
- docs/docs/reference/technical-design.md

The links have been updated to point to the correct locations, resolving the htmlproofer errors.