### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/docs/guides/advanced-usage.md
+++ b/docs/docs/guides/advanced-usage.md
@@ -24,7 +24,7 @@ The `Makefile` at the root of the project provides a number of helpful commands 
 
 If you have an existing homelab that was configured manually, you can use the `homelab-importer` tool to import it into a Terraform-managed setup. This is a great way to migrate your existing homelab to the Infrastructure as Code (IaC) approach used by this project.
 
-For detailed instructions on how to use the importer, please see the [Technical Design](../reference/technical-design.md) guide.
+For detailed instructions on how to use the importer, please see the [Technical Design](../reference/technical-design.html) guide.
 
 ## OpenLDAP
 

--- a/docs/docs/reference/technical-design.md
+++ b/docs/docs/reference/technical-design.md
@@ -211,7 +211,7 @@ The project uses a VLAN-based network segmentation strategy to isolate traffic a
 
 ## 5. Scalability and Customization
 
-This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide](../guides/customization.md).
+This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide](../guides/customization.html).
 
 ---
 


### PR DESCRIPTION
The htmlproofer build was failing due to two broken internal links in the documentation. The links were pointing to `.md` files instead of the generated `.html` files.

This commit fixes the links by changing the file extension from `.md` to `.html`.