### PR TITLE
feat: Implement styling overhaul for Jekyll documentation site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -84,16 +84,27 @@ nav_sort: case_sensitive
 nav_external_links:
   - title: Homelabeazy on GitHub
     url: https://github.com/toxicoder/homelabeazy
+
+# Set the base color scheme to dark (will be overridden by custom SCSS)
+color_scheme: dark
+
+# Define custom callouts for different alert types
+callouts_level: quiet # or loud
 callouts:
+  highlight:
+    color: yellow
+  important:
+    title: Important
+    color: blue
+  new:
+    title: New
+    color: green
+  note:
+    title: Note
+    color: purple
   warning:
     title: Warning
     color: red
-  info:
-    title: Info
-    color: blue
-  success:
-    title: Success
-    color: green
 aux_links:
   "Homelabeazy on GitHub":
     - "https://github.com/toxicoder/homelabeazy"

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,122 @@
+// In docs/_sass/custom/custom.scss
+
+/*--------------------------------------------------------------
+# General Theme Colors and Typography
+--------------------------------------------------------------*/
+// Set the primary background color for the content area
+$body-background-color: #f2f4f8;
+
+// Set the sidebar background color
+$sidebar-color: #e8ebf2;
+
+// Define text, heading, and link colors for readability
+$body-text-color: #3d4554;
+$body-heading-color: #1e2229;
+$link-color: #0066cc;
+
+// Set a border color for elements like tables and horizontal rules
+$border-color: #d1d5da;
+
+/*--------------------------------------------------------------
+# Navigation and Buttons
+--------------------------------------------------------------*/
+// Style the main navigation links in the sidebar
+.site-nav {
+  a {
+    color: #555e6d;
+    &:hover {
+      color: #000;
+    }
+  }
+}
+
+// Style the primary (purple) button
+.btn-primary {
+  background-color: #6f42c1;
+  color: #fff;
+  border: 1px solid #6f42c1;
+
+  &:hover {
+    background-color: darken(#6f42c1, 10%);
+    color: #fff;
+  }
+}
+
+// Style the default (light grey) button
+.btn {
+  background-color: #f6f8fa;
+  color: #24292e;
+  border: 1px solid rgba(27, 31, 35, 0.15);
+
+  &:hover {
+    background-color: #e6ebf1;
+  }
+}
+
+/*--------------------------------------------------------------
+# Content Elements
+--------------------------------------------------------------*/
+// Style for tables
+table {
+  border-collapse: collapse;
+  width: 100%;
+  border: 1px solid $border-color;
+}
+
+th, td {
+  border: 1px solid $border-color;
+  padding: 10px;
+  text-align: left;
+}
+
+th {
+  background-color: #e8ebf2; // Use sidebar color for header
+}
+
+// Style for blockquotes
+blockquote {
+  border-left: 4px solid $border-color;
+  padding-left: 1rem;
+  color: #555e6d;
+}
+
+// Style for horizontal rules
+hr {
+  border-top: 1px solid $border-color;
+}
+
+// Ensure code blocks have a consistent, readable style
+code, pre {
+  background-color: #e8ebf2; // Light background for code
+  color: $body-text-color;
+  border-radius: 3px;
+}
+
+pre {
+  padding: 1rem;
+}
+
+
+/*--------------------------------------------------------------
+# Custom Callouts
+--------------------------------------------------------------*/
+.callout {
+  padding: 1.25rem;
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+  border: 1px solid transparent;
+  border-left-width: 0.25rem;
+  border-radius: 0.25rem;
+
+  // Warning callout (red)
+  &.warning {
+    border-left-color: #d73a49;
+    background-color: rgba(215, 58, 73, 0.1);
+  }
+
+  // Note callout (purple)
+  &.note {
+    border-left-color: #6f42c1;
+    background-color: rgba(111, 66, 193, 0.1);
+  }
+}


### PR DESCRIPTION
This commit introduces a comprehensive styling overhaul for the Jekyll documentation site, which uses the 'Just the Docs' theme.

The changes include:
- Updating `docs/_config.yml` to set the base color scheme to dark and define custom callouts for different alert types.
- Creating a new custom SCSS file at `docs/_sass/custom/custom.scss` to implement the full visual theme, including general theme colors, typography, navigation, buttons, and content elements.