### PR TITLE
Fix(docs): set baseurl for github pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,6 +21,7 @@ description: >- # used by seo meta and the atom feed
 # Fill in the protocol & hostname for your site.
 # E.g. 'https://username.github.io', note that it does not end with a '/'.
 url: "https://toxicoder.github.io"
+baseurl: "/homelabeazy"
 
 github:
   username: toxicoder # change to your GitHub username
@@ -33,9 +34,6 @@ search_enabled: true
 
 # boolean type, the global switch for TOC in posts.
 toc: true
-
-# The base URL of your site
-baseurl: ""
 
 # ------------ The following options are not recommended to be modified ------------------
 


### PR DESCRIPTION
Set the `baseurl` in `docs/_config.yml` to `/homelabeazy` to correctly resolve asset paths on the GitHub Pages site.

This ensures that CSS and other assets are loaded correctly, fixing the unstyled rendering of the documentation.