### PR TITLE
fix(docs): Fix broken links in documentation build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           bundle exec htmlproofer ./_site \
             --disable-external \
-            --url-ignore "/\/#.*/,/#.*/"
+            --url-ignore "/\/#.*/,/#.*/" \
+            --swap-urls '^/homelabeazy/:/'
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
 


### PR DESCRIPTION
The htmlproofer check was failing due to a misconfigured base URL. This change adds the --swap-urls option to the htmlproofer command to correctly handle the /homelabeazy base URL, resolving the broken link errors.