### PR TITLE
Fix(deps): Correct htmlproofer command in docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,7 @@ jobs:
           bundle exec htmlproofer ./_site \
             --disable-external \
             --url-ignore "/\/#.*/,/#.*/" \
-            --swap-urls '^/homelabeazy/:/'
+            --url-swap '^/homelabeazy/:/'
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
 


### PR DESCRIPTION
The htmlproofer command in the deploy-docs.yml workflow was failing due to an invalid option, `--swap-urls`.

This commit replaces the incorrect `--swap-urls` option with the correct `--url-swap` option, which resolves the workflow failure.