### PR TITLE
Docs: Improve formatting and fix links

### DIFF
--- a/PRIVATE_DEPLOYMENT.md
+++ b/PRIVATE_DEPLOYMENT.md
@@ -33,6 +33,7 @@ By using the interactive setup, you can avoid the manual steps that were previou
 ## Manual Setup (Advanced)
 
 If you prefer to set up your private deployment manually, you can still do so. The basic steps are:
+
 1. Create a private git repository for your configuration.
 2. Copy the contents of the `config.example/` directory into your private repository.
 3. Customize the configuration files to match your environment.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**For full documentation, visit our <a href="https://toxicoder.github.io/homelabeazy" target="_blank">GitHub Pages site</a>.**
+**For full documentation, visit our [GitHub Pages site](https://toxicoder.github.io/homelabeazy).**
 
 # Homelabeazy - Your _Homelab as Code_
 
@@ -20,9 +20,9 @@ This project automates the setup of a homelab environment on a Proxmox server us
 
 It:
 
-1. **provisions a K3s cluster**
-1. **configures the nodes**
-1. **and deploys a suite of applications using a GitOps approach.**
+- **provisions a K3s cluster**
+- **configures the nodes**
+- **and deploys a suite of applications using a GitOps approach.**
 
 The project is designed to be idempotent and modular, allowing you to easily customize your homelab by adding or removing applications to fit your needs.
 

--- a/docs/docs/guides/advanced-usage.md
+++ b/docs/docs/guides/advanced-usage.md
@@ -24,17 +24,16 @@ The `Makefile` at the root of the project provides a number of helpful commands 
 
 If you have an existing homelab that was configured manually, you can use the `homelab-importer` tool to import it into a Terraform-managed setup. This is a great way to migrate your existing homelab to the Infrastructure as Code (IaC) approach used by this project.
 
-For detailed instructions on how to use the importer, please see the [Technical Design](../reference/technical-design.html) guide.
+For detailed instructions on how to use the importer, please see the [Technical Design]({% link docs/reference/technical-design.md %}) guide.
 
 ## OpenLDAP
 
 This project includes an Ansible role for deploying OpenLDAP to your Kubernetes cluster. OpenLDAP is used as the central user directory for your homelab, and it is integrated with Authelia to provide Single Sign-On (SSO) for your applications.
 
-The OpenLDAP passwords are managed by Vault. You will need to add the following secrets to Vault:
+The OpenLDAP passwords are managed by Vault. You will need to add the following secrets to Vault at the path `secrets/data/openldap`:
 
--   `secrets/data/openldap`
-    -   `root-password`
-    -   `admin-password`
+-   `root-password`
+-   `admin-password`
 
 ## Stealth VM
 

--- a/docs/docs/guides/customization.md
+++ b/docs/docs/guides/customization.md
@@ -17,7 +17,6 @@ The heart of your homelab is the applications you run on it. Homelabeazy uses a 
 4.  **Add the new application to the "app of apps":** Add a new entry for your application in the `apps/app-of-apps.yml` file. This will tell ArgoCD to start managing your new application.
 5.  **Commit and push your changes:** Once you commit and push your changes to your Git repository, ArgoCD will automatically detect the new application and deploy it to your cluster.
 
-For a more detailed walkthrough of this process, please see the [Adding New Applications](#adding-new-applications) guide.
 
 ## Managing Secrets
 

--- a/docs/docs/guides/getting-started.md
+++ b/docs/docs/guides/getting-started.md
@@ -120,4 +120,4 @@ You've now successfully set up your homelab and deployed your first application.
 *   **Explore the available applications:** The Homelabeazy project comes with a number of pre-configured applications that you can deploy to your cluster. Check out the `apps/` directory in the repository.
 *   **Add your own applications:** You can easily add your own applications to your homelab by creating new Helm charts or by using existing ones.
 *   **Customize your setup:** The Homelabeazy project is highly customizable. You can change the network configuration, add new services, and integrate with other systems.
-*   **Contribute to the project:** If you've found a bug or have an idea for a new feature, we'd love to hear from you! Check out our [Contributing Guide](./community) for more information.
+*   **Contribute to the project:** If you've found a bug or have an idea for a new feature, we'd love to hear from you! Check out our [Contributing Guide]({% link docs/community.md %}) for more information.

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -5,7 +5,7 @@ parent: Guides
 
 # Troubleshooting
 
-This guide provides solutions to common problems you may encounter while using Homelabeazy. If you can't find a solution to your problem here, please feel free to [open an issue](https://github.com/homelabeazy/homelabeazy/issues) on our GitHub repository.
+This guide provides solutions to common problems you may encounter while using Homelabeazy. If you can't find a solution to your problem here, please feel free to [open an issue](https://github.com/toxicoder/homelabeazy/issues) on our GitHub repository.
 
 ## Setup and Installation Issues
 
@@ -81,4 +81,4 @@ If you encounter an issue that you cannot resolve, you can restart the setup pro
     rm infrastructure/proxmox/terraform.tfvars
     rm ansible/inventory/inventory.auto.yml
     ```
-3.  **Run the setup process again by following the steps in the [Getting Started](./getting-started) guide.**
+3.  **Run the setup process again by following the steps in the [Getting Started]({% link docs/guides/getting-started.md %}) guide.**

--- a/docs/docs/reference/deployment.md
+++ b/docs/docs/reference/deployment.md
@@ -47,4 +47,4 @@ This will install K3s on the virtual machines and configure them to form a Kuber
 
 Applications are deployed to your cluster using a GitOps workflow with ArgoCD. To deploy a new application, you'll need to create a new YAML file in the `apps/` directory of your private configuration repository.
 
-For more information on how to add new applications, please see the [Customization](./customization) guide.
+For more information on how to add new applications, please see the [Customization]({% link docs/guides/customization.md %}) guide.

--- a/docs/docs/reference/technical-design.md
+++ b/docs/docs/reference/technical-design.md
@@ -11,7 +11,7 @@ Welcome to the Technical Design Document for Homelabeazy. This document provides
 
 ### Who is this for?
 
-This document is intended for users who have a basic understanding of the core technologies used in this project, such as Proxmox, Terraform, Ansible, and Kubernetes. If you're new to these technologies, we recommend that you start with our [Getting Started guide](../guides/) and then come back to this document for a deeper dive.
+This document is intended for users who have a basic understanding of the core technologies used in this project, such as Proxmox, Terraform, Ansible, and Kubernetes. If you're new to these technologies, we recommend that you start with our [Getting Started guide]({% link docs/guides/getting-started.md %}) and then come back to this document for a deeper dive.
 
 ### Design Philosophy
 
@@ -211,7 +211,7 @@ The project uses a VLAN-based network segmentation strategy to isolate traffic a
 
 ## 5. Scalability and Customization
 
-This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide](../guides/customization.html).
+This project is designed to be both scalable and customizable. You can easily scale your cluster by adding more worker nodes, and you can customize the project by adding your own applications, configuring services, and modifying the infrastructure. For detailed instructions, please refer to the [Customization Guide]({% link docs/guides/customization.md %}).
 
 ---
 


### PR DESCRIPTION
This commit improves the formatting of the project's documentation and fixes several issues, including:

- Standardized all internal links in the documentation to use Jekyll's `{% link %}` tag for consistency and to prevent broken links.
- Fixed the formatting of the main `README.md` file by replacing an HTML link with a standard markdown link and changing a numbered list to a bulleted list.
- Improved the formatting of `PRIVATE_DEPLOYMENT.md` by changing the manual setup steps to a numbered list for better readability.
- Corrected the formatting in `docs/docs/guides/advanced-usage.md` by reformatting the list of OpenLDAP secrets to be more clear and readable.
- Removed a redundant link in `docs/docs/guides/customization.md`.
- Fixed miscellaneous link issues in the documentation, including correcting the raw URL for opening an issue in `troubleshooting.md`.